### PR TITLE
feat: move `JsonRpcRequest` to its own file

### DIFF
--- a/src/json-rpc-request.test.ts
+++ b/src/json-rpc-request.test.ts
@@ -1,0 +1,57 @@
+import { JsonRpcRequestStruct } from './json-rpc-request';
+
+describe('JsonRpcRequestStruct', () => {
+  it('should be a valid JsonRpcRequest with a numerical ID', () => {
+    const request = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'my_method',
+      params: [1, 2, 3],
+    };
+
+    expect(JsonRpcRequestStruct.is(request)).toBe(true);
+  });
+
+  it('should be a valid JsonRpcRequest with a string ID', () => {
+    const request = {
+      jsonrpc: '2.0',
+      id: 'request_id',
+      method: 'my_method',
+      params: [1, 2, 3],
+    };
+
+    expect(JsonRpcRequestStruct.is(request)).toBe(true);
+  });
+
+  it('should be a valid JsonRpcRequest with a null ID', () => {
+    const request = {
+      jsonrpc: '2.0',
+      id: null,
+      method: 'my_method',
+      params: [1, 2, 3],
+    };
+
+    expect(JsonRpcRequestStruct.is(request)).toBe(true);
+  });
+
+  it('should be a valid JsonRpcRequest without params', () => {
+    const request = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'my_method',
+    };
+
+    expect(JsonRpcRequestStruct.is(request)).toBe(true);
+  });
+
+  it('should not be a valid JsonRpcRequest if params is undefined', () => {
+    const request = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'my_method',
+      params: undefined,
+    };
+
+    expect(JsonRpcRequestStruct.is(request)).toBe(false);
+  });
+});

--- a/src/json-rpc-request.ts
+++ b/src/json-rpc-request.ts
@@ -1,0 +1,32 @@
+import { JsonStruct } from '@metamask/utils';
+import {
+  Infer,
+  array,
+  literal,
+  nullable,
+  number,
+  object,
+  record,
+  string,
+  union,
+} from 'superstruct';
+
+const Common = {
+  jsonrpc: literal('2.0'),
+  id: nullable(union([string(), number()])),
+  method: string(),
+};
+
+const Params = {
+  params: union([array(JsonStruct), record(string(), JsonStruct)]),
+};
+
+export const JsonRpcRequestStruct = union([
+  object({ ...Common }),
+  object({ ...Common, ...Params }),
+]);
+
+/**
+ * JSON-RPC request type.
+ */
+export type JsonRpcRequest = Infer<typeof JsonRpcRequestStruct>;

--- a/src/keyring-api.ts
+++ b/src/keyring-api.ts
@@ -11,6 +11,7 @@ import {
   array,
 } from 'superstruct';
 
+import { JsonRpcRequestStruct } from './json-rpc-request';
 import { UuidStruct } from './utils';
 
 export const KeyringAccountStruct = object({
@@ -64,28 +65,6 @@ export const KeyringAccountStruct = object({
  */
 export type KeyringAccount = Infer<typeof KeyringAccountStruct>;
 
-export const KeyringJsonRpcRequestStruct = union([
-  object({
-    jsonrpc: literal('2.0'),
-    id: string(),
-    method: string(),
-  }),
-  object({
-    jsonrpc: literal('2.0'),
-    id: string(),
-    method: string(),
-    params: union([array(JsonStruct), record(string(), JsonStruct)]),
-  }),
-]);
-
-/**
- * JSON-RPC request type.
- *
- * Represents a JSON-RPC request sent by a dApp. The request ID must be a
- * string and the params field cannot be undefined.
- */
-export type KeyringJsonRpcRequest = Infer<typeof KeyringJsonRpcRequestStruct>;
-
 export const KeyringRequestStruct = object({
   /**
    * Account ID (UUIDv4).
@@ -102,7 +81,7 @@ export const KeyringRequestStruct = object({
    *
    * Note: The request ID must be a string.
    */
-  request: KeyringJsonRpcRequestStruct,
+  request: JsonRpcRequestStruct,
 });
 
 /**

--- a/src/keyring-internal-api.ts
+++ b/src/keyring-internal-api.ts
@@ -18,12 +18,16 @@ import {
 } from './keyring-api';
 import { UuidStruct } from './utils';
 
+const CommonHeader = {
+  jsonrpc: literal('2.0'),
+  id: UuidStruct,
+};
+
 // ----------------------------------------------------------------------------
 // List accounts
 
 export const ListAccountsRequestStruct = object({
-  id: UuidStruct,
-  jsonrpc: literal('2.0'),
+  ...CommonHeader,
   method: literal('keyring_listAccounts'),
 });
 
@@ -37,8 +41,7 @@ export type ListAccountsResponse = Infer<typeof ListAccountsResponseStruct>;
 // Get account
 
 export const GetAccountRequestStruct = object({
-  id: UuidStruct,
-  jsonrpc: literal('2.0'),
+  ...CommonHeader,
   method: literal('keyring_getAccount'),
   params: object({
     id: string(),
@@ -55,8 +58,7 @@ export type GetAccountResponse = Infer<typeof GetAccountResponseStruct>;
 // Create account
 
 export const CreateAccountRequestStruct = object({
-  id: UuidStruct,
-  jsonrpc: literal('2.0'),
+  ...CommonHeader,
   method: literal('keyring_createAccount'),
   params: object({
     name: string(),
@@ -74,8 +76,7 @@ export type CreateAccountResponse = Infer<typeof CreateAccountResponseStruct>;
 // Filter account chains
 
 export const FilterAccountChainsStruct = object({
-  id: UuidStruct,
-  jsonrpc: literal('2.0'),
+  ...CommonHeader,
   method: literal('keyring_filterAccountChains'),
   params: object({
     id: string(),
@@ -97,8 +98,7 @@ export type FilterAccountChainsResponse = Infer<
 // Update account
 
 export const UpdateAccountRequestStruct = object({
-  id: UuidStruct,
-  jsonrpc: literal('2.0'),
+  ...CommonHeader,
   method: literal('keyring_updateAccount'),
   params: object({
     account: KeyringAccountStruct,
@@ -115,8 +115,7 @@ export type UpdateAccountResponse = Infer<typeof UpdateAccountResponseStruct>;
 // Delete account
 
 export const DeleteAccountRequestStruct = object({
-  id: UuidStruct,
-  jsonrpc: literal('2.0'),
+  ...CommonHeader,
   method: literal('keyring_deleteAccount'),
   params: object({
     id: string(),
@@ -133,8 +132,7 @@ export type DeleteAccountResponse = Infer<typeof DeleteAccountResponseStruct>;
 // List requests
 
 export const ListRequestsRequestStruct = object({
-  id: UuidStruct,
-  jsonrpc: literal('2.0'),
+  ...CommonHeader,
   method: literal('keyring_listRequests'),
 });
 
@@ -148,8 +146,7 @@ export type ListRequestsResponse = Infer<typeof ListRequestsResponseStruct>;
 // Get request
 
 export const GetRequestRequestStruct = object({
-  id: UuidStruct,
-  jsonrpc: literal('2.0'),
+  ...CommonHeader,
   method: literal('keyring_getRequest'),
   params: object({
     id: string(),
@@ -166,8 +163,7 @@ export type GetRequestResponse = Infer<typeof GetRequestResponseStruct>;
 // Submit request
 
 export const SubmitRequestRequestStruct = object({
-  id: UuidStruct,
-  jsonrpc: literal('2.0'),
+  ...CommonHeader,
   method: literal('keyring_submitRequest'),
   params: KeyringRequestStruct,
 });
@@ -181,8 +177,7 @@ export type SubmitRequestRequest = Infer<typeof SubmitRequestRequestStruct>;
 // Approve request
 
 export const ApproveRequestRequestStruct = object({
-  id: UuidStruct,
-  jsonrpc: literal('2.0'),
+  ...CommonHeader,
   method: literal('keyring_approveRequest'),
   params: object({
     id: string(),
@@ -199,8 +194,7 @@ export type ApproveRequestResponse = Infer<typeof ApproveRequestResponseStruct>;
 // Reject request
 
 export const RejectRequestRequestStruct = object({
-  id: UuidStruct,
-  jsonrpc: literal('2.0'),
+  ...CommonHeader,
   method: literal('keyring_rejectRequest'),
   params: object({
     id: string(),

--- a/src/keyring-rpc-dispatcher.test.ts
+++ b/src/keyring-rpc-dispatcher.test.ts
@@ -1,5 +1,4 @@
-import type { Json, JsonRpcRequest } from '@metamask/utils';
-
+import { JsonRpcRequest } from './json-rpc-request';
 import {
   MethodNotSupportedError,
   buildHandlersChain,
@@ -11,7 +10,7 @@ describe('buildHandlersChain', () => {
   const handler2 = jest.fn();
   const handler3 = jest.fn();
 
-  const request: JsonRpcRequest<Json[] | Record<string, Json>> = {
+  const request: JsonRpcRequest = {
     jsonrpc: '2.0',
     id: 'test-id',
     method: 'test_method',
@@ -145,9 +144,7 @@ describe('keyringRpcDispatcher', () => {
 
     await expect(
       handleKeyringRequest(keyring, request as unknown as JsonRpcRequest),
-    ).rejects.toThrow(
-      'At path: method -- Expected a string, but received: undefined',
-    );
+    ).rejects.toThrow('Expected the value to satisfy a union of');
   });
 
   it('should call keyring_getAccount', async () => {
@@ -346,6 +343,18 @@ describe('keyringRpcDispatcher', () => {
 
     expect(keyring.approveRequest).toHaveBeenCalledWith('request_id');
     expect(result).toBe('ApproveRequest result');
+  });
+
+  it('should fail to list requests with a non-UUIDv4 request ID', async () => {
+    const request: JsonRpcRequest = {
+      jsonrpc: '2.0',
+      id: 'invalid-id-string',
+      method: 'keyring_listRequests',
+    };
+
+    await expect(handleKeyringRequest(keyring, request)).rejects.toThrow(
+      'At path: id -- Expected a string matching',
+    );
   });
 
   it('should call keyring_rejectRequest', async () => {

--- a/src/keyring-rpc-dispatcher.ts
+++ b/src/keyring-rpc-dispatcher.ts
@@ -1,11 +1,8 @@
 import type { OnRpcRequestHandler } from '@metamask/snaps-utils';
-import {
-  JsonRpcRequestStruct,
-  type Json,
-  JsonRpcRequest,
-} from '@metamask/utils';
+import type { Json } from '@metamask/utils';
 import { assert } from 'superstruct';
 
+import { JsonRpcRequest, JsonRpcRequestStruct } from './json-rpc-request';
 import type { Keyring } from './keyring-api';
 import {
   GetAccountRequestStruct,
@@ -75,6 +72,7 @@ export async function handleKeyringRequest(
   // We first have to make sure that the request is a valid JSON-RPC request so
   // we can check its method name.
   assert(request, JsonRpcRequestStruct);
+
   switch (request.method) {
     case 'keyring_listAccounts': {
       assert(request, ListAccountsRequestStruct);


### PR DESCRIPTION
This PR moves the `JsonRpcRequest` and `JsonRpcRequestStruct` definitions to their own file.