### PR TITLE
feature: make `options` a mandatory field of `KeyringAccount`

### DIFF
--- a/src/KeyringClient.test.ts
+++ b/src/KeyringClient.test.ts
@@ -23,7 +23,7 @@ describe('KeyringClient', () => {
           id: '49116980-0712-4fa5-b045-e4294f1d440e',
           name: 'Account 1',
           address: '0xE9A74AACd7df8112911ca93260fC5a046f8a64Ae',
-          options: null,
+          options: {},
           supportedMethods: [],
           type: 'eip155:eoa',
         },
@@ -47,7 +47,7 @@ describe('KeyringClient', () => {
         id: '49116980-0712-4fa5-b045-e4294f1d440e',
         name: 'Account 1',
         address: '0xE9A74AACd7df8112911ca93260fC5a046f8a64Ae',
-        options: null,
+        options: {},
         supportedMethods: [],
         type: 'eip155:eoa',
       };
@@ -70,7 +70,7 @@ describe('KeyringClient', () => {
         id: '49116980-0712-4fa5-b045-e4294f1d440e',
         name: 'Account 1',
         address: '0xE9A74AACd7df8112911ca93260fC5a046f8a64Ae',
-        options: null,
+        options: {},
         supportedMethods: [],
         type: 'eip155:eoa',
       };
@@ -81,7 +81,7 @@ describe('KeyringClient', () => {
         jsonrpc: '2.0',
         id: expect.any(String),
         method: 'keyring_createAccount',
-        params: { name: 'Account 1', options: null },
+        params: { name: 'Account 1', options: {} },
       });
       expect(account).toStrictEqual(expectedResponse);
     });
@@ -113,7 +113,7 @@ describe('KeyringClient', () => {
         id: '49116980-0712-4fa5-b045-e4294f1d440e',
         name: 'Account 1',
         address: '0xE9A74AACd7df8112911ca93260fC5a046f8a64Ae',
-        options: null,
+        options: {},
         supportedMethods: [],
         type: 'eip155:eoa',
       };

--- a/src/KeyringClient.ts
+++ b/src/KeyringClient.ts
@@ -78,7 +78,7 @@ export class KeyringClient implements Keyring {
 
   async createAccount(
     name: string,
-    options: Record<string, Json> | null = null,
+    options: Record<string, Json> = {},
   ): Promise<KeyringAccount> {
     return strictMask(
       await this.#send({

--- a/src/KeyringSnapControllerClient.test.ts
+++ b/src/KeyringSnapControllerClient.test.ts
@@ -11,7 +11,7 @@ describe('KeyringSnapControllerClient', () => {
       id: '13f94041-6ae6-451f-a0fe-afdd2fda18a7',
       name: 'Account 1',
       address: '0xE9A74AACd7df8112911ca93260fC5a046f8a64Ae',
-      options: null,
+      options: {},
       supportedMethods: [],
       type: 'eip155:eoa',
     },

--- a/src/KeyringSnapRpcClient.test.ts
+++ b/src/KeyringSnapRpcClient.test.ts
@@ -11,7 +11,7 @@ describe('KeyringSnapRpcClient', () => {
       id: '13f94041-6ae6-451f-a0fe-afdd2fda18a7',
       name: 'Account 1',
       address: '0xE9A74AACd7df8112911ca93260fC5a046f8a64Ae',
-      options: null,
+      options: {},
       supportedMethods: [],
       type: 'eip155:eoa',
     },

--- a/src/api.ts
+++ b/src/api.ts
@@ -33,7 +33,7 @@ export const KeyringAccountStruct = object({
   /**
    * Keyring-dependent account options.
    */
-  options: nullable(record(string(), JsonStruct)),
+  options: record(string(), JsonStruct),
 
   /**
    * Account supported methods.
@@ -147,7 +147,7 @@ export type Keyring = {
    */
   createAccount(
     name: string,
-    options?: Record<string, Json> | null,
+    options?: Record<string, Json>,
   ): Promise<KeyringAccount>;
 
   /**

--- a/src/internal-api.ts
+++ b/src/internal-api.ts
@@ -62,7 +62,7 @@ export const CreateAccountRequestStruct = object({
   method: literal('keyring_createAccount'),
   params: object({
     name: string(),
-    options: nullable(record(string(), JsonStruct)),
+    options: record(string(), JsonStruct),
   }),
 });
 


### PR DESCRIPTION
This is a **breaking change**.

This PR changes the `KeyringAccount` type to make `options` a mandatory field (non-nullable).