### PR TITLE
refactor: rename `supportedMethods` to `methods`

### DIFF
--- a/src/KeyringClient.test.ts
+++ b/src/KeyringClient.test.ts
@@ -24,7 +24,7 @@ describe('KeyringClient', () => {
           name: 'Account 1',
           address: '0xE9A74AACd7df8112911ca93260fC5a046f8a64Ae',
           options: {},
-          supportedMethods: [],
+          methods: [],
           type: 'eip155:eoa',
         },
       ];
@@ -48,7 +48,7 @@ describe('KeyringClient', () => {
         name: 'Account 1',
         address: '0xE9A74AACd7df8112911ca93260fC5a046f8a64Ae',
         options: {},
-        supportedMethods: [],
+        methods: [],
         type: 'eip155:eoa',
       };
 
@@ -71,7 +71,7 @@ describe('KeyringClient', () => {
         name: 'Account 1',
         address: '0xE9A74AACd7df8112911ca93260fC5a046f8a64Ae',
         options: {},
-        supportedMethods: [],
+        methods: [],
         type: 'eip155:eoa',
       };
 
@@ -114,7 +114,7 @@ describe('KeyringClient', () => {
         name: 'Account 1',
         address: '0xE9A74AACd7df8112911ca93260fC5a046f8a64Ae',
         options: {},
-        supportedMethods: [],
+        methods: [],
         type: 'eip155:eoa',
       };
 

--- a/src/KeyringSnapControllerClient.test.ts
+++ b/src/KeyringSnapControllerClient.test.ts
@@ -12,7 +12,7 @@ describe('KeyringSnapControllerClient', () => {
       name: 'Account 1',
       address: '0xE9A74AACd7df8112911ca93260fC5a046f8a64Ae',
       options: {},
-      supportedMethods: [],
+      methods: [],
       type: 'eip155:eoa',
     },
   ];

--- a/src/KeyringSnapRpcClient.test.ts
+++ b/src/KeyringSnapRpcClient.test.ts
@@ -12,7 +12,7 @@ describe('KeyringSnapRpcClient', () => {
       name: 'Account 1',
       address: '0xE9A74AACd7df8112911ca93260fC5a046f8a64Ae',
       options: {},
-      supportedMethods: [],
+      methods: [],
       type: 'eip155:eoa',
     },
   ];

--- a/src/api.ts
+++ b/src/api.ts
@@ -38,7 +38,7 @@ export const KeyringAccountStruct = object({
   /**
    * Account supported methods.
    */
-  supportedMethods: array(
+  methods: array(
     enums([
       'personal_sign',
       'eth_sendTransaction',

--- a/src/rpc-handler.test.ts
+++ b/src/rpc-handler.test.ts
@@ -238,7 +238,7 @@ describe('keyringRpcDispatcher', () => {
           name: 'test',
           address: '0x0',
           options: {},
-          supportedMethods: [],
+          methods: [],
           type: 'eip155:eoa',
         },
       },
@@ -252,7 +252,7 @@ describe('keyringRpcDispatcher', () => {
       name: 'test',
       address: '0x0',
       options: {},
-      supportedMethods: [],
+      methods: [],
       type: 'eip155:eoa',
     });
     expect(result).toBe('UpdateAccount result');


### PR DESCRIPTION
BREAKING CHANGE: This commit renames a field of the KeyringAccount class, making it incompatible with previous versions.