### PR TITLE
fix: rename `erc4337` -> `eip4337`

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -55,7 +55,7 @@ export const KeyringAccountStruct = object({
   /**
    * Account type.
    */
-  type: enums(['eip155:eoa', 'eip155:erc4337']),
+  type: enums(['eip155:eoa', 'eip155:eip4337']),
 });
 
 /**


### PR DESCRIPTION
BREAKING CHANGE: This PR changes the allowed types of an account.