### PR TITLE
feat: add `getController` to client

### DIFF
--- a/src/KeyringSnapControllerClient.test.ts
+++ b/src/KeyringSnapControllerClient.test.ts
@@ -69,4 +69,14 @@ describe('KeyringSnapControllerClient', () => {
       });
     });
   });
+
+  describe('getController', () => {
+    it('should return the controller', () => {
+      const client = new KeyringSnapControllerClient({
+        controller: controller as unknown as SnapController,
+      });
+
+      expect(client.getController()).toBe(controller);
+    });
+  });
 });

--- a/src/KeyringSnapControllerClient.ts
+++ b/src/KeyringSnapControllerClient.ts
@@ -110,4 +110,13 @@ export class KeyringSnapControllerClient extends KeyringClient {
       snapId,
     });
   }
+
+  /**
+   * Get the `SnapController` instance used by this client.
+   *
+   * @returns The `SnapController` instance used by this client.
+   */
+  getController(): SnapController {
+    return this.#controller;
+  }
 }


### PR DESCRIPTION
This PR adds the `getController` method to the `KeyringSnapControllerClient` class.