### PR TITLE
feat: remove `eth_sendTransaction` method

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -41,7 +41,6 @@ export const KeyringAccountStruct = object({
   methods: array(
     enums([
       'personal_sign',
-      'eth_sendTransaction',
       'eth_sign',
       'eth_signTransaction',
       'eth_signTypedData',


### PR DESCRIPTION
Rationale: we shouldn't expect keyrings to broadcast transactions, only to sign them.

BREAKING CHANGE: This commit removes the `eth_sendTransaction` from the allowed methods.