### PR TITLE
chore(deps): bump `@metamask/snaps-*` to 0.36.0-flask.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
   },
   "dependencies": {
     "@metamask/providers": "^11.0.0",
-    "@metamask/snaps-controllers": "^0.35.2-flask.1",
-    "@metamask/snaps-utils": "^0.35.2-flask.1",
+    "@metamask/snaps-controllers": "^0.36.0-flask.1",
+    "@metamask/snaps-utils": "^0.36.0-flask.1",
     "@metamask/utils": "^6.0.1",
     "@types/uuid": "^9.0.1",
     "superstruct": "^1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1101,8 +1101,8 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/providers": ^11.0.0
-    "@metamask/snaps-controllers": ^0.35.2-flask.1
-    "@metamask/snaps-utils": ^0.35.2-flask.1
+    "@metamask/snaps-controllers": ^0.36.0-flask.1
+    "@metamask/snaps-utils": ^0.36.0-flask.1
     "@metamask/utils": ^6.0.1
     "@types/jest": ^28.1.6
     "@types/node": ^16
@@ -1192,21 +1192,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/rpc-methods@npm:^0.35.2-flask.1":
-  version: 0.35.2-flask.1
-  resolution: "@metamask/rpc-methods@npm:0.35.2-flask.1"
+"@metamask/rpc-methods@npm:^0.36.0-flask.1":
+  version: 0.36.0-flask.1
+  resolution: "@metamask/rpc-methods@npm:0.36.0-flask.1"
   dependencies:
     "@metamask/key-tree": ^7.1.1
     "@metamask/permission-controller": ^4.0.0
-    "@metamask/snaps-ui": ^0.35.2-flask.1
-    "@metamask/snaps-utils": ^0.35.2-flask.1
+    "@metamask/snaps-ui": ^0.36.0-flask.1
+    "@metamask/snaps-utils": ^0.36.0-flask.1
     "@metamask/types": ^1.1.0
     "@metamask/utils": ^6.0.1
     "@noble/hashes": ^1.3.1
     eth-rpc-errors: ^4.0.3
     nanoid: ^3.1.31
     superstruct: ^1.0.3
-  checksum: e949da37c7d3099c07fc3f110310a1f86dbfbdf0d3a84a584b697beb64dc4662ba93e843b7a28a41e41b6500128782a07a9884e14252ac98206b8ed58776034b
+  checksum: 0a6560737053015e1ef550d845f8540568451655d4cd24e1a28a2513a8aba4616b2147fdd257e6c803020fe29b687bd2e00a78eab0e0f9379d67ecd1d9a9c917
   languageName: node
   linkType: hard
 
@@ -1234,19 +1234,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-controllers@npm:^0.35.2-flask.1":
-  version: 0.35.2-flask.1
-  resolution: "@metamask/snaps-controllers@npm:0.35.2-flask.1"
+"@metamask/snaps-controllers@npm:^0.36.0-flask.1":
+  version: 0.36.0-flask.1
+  resolution: "@metamask/snaps-controllers@npm:0.36.0-flask.1"
   dependencies:
     "@metamask/approval-controller": ^3.0.0
     "@metamask/base-controller": ^3.0.0
     "@metamask/object-multiplex": ^1.2.0
     "@metamask/permission-controller": ^4.0.0
     "@metamask/post-message-stream": ^6.1.2
-    "@metamask/rpc-methods": ^0.35.2-flask.1
-    "@metamask/snaps-execution-environments": ^0.35.2-flask.1
+    "@metamask/rpc-methods": ^0.36.0-flask.1
+    "@metamask/snaps-execution-environments": ^0.36.0-flask.1
     "@metamask/snaps-registry": ^1.2.1
-    "@metamask/snaps-utils": ^0.35.2-flask.1
+    "@metamask/snaps-utils": ^0.36.0-flask.1
     "@metamask/utils": ^6.0.1
     "@xstate/fsm": ^2.0.0
     concat-stream: ^2.0.0
@@ -1260,19 +1260,19 @@ __metadata:
     pump: ^3.0.0
     readable-web-to-node-stream: ^3.0.2
     tar-stream: ^2.2.0
-  checksum: 8b20ed3176da02c2bb5be642db83912b484dd85a0e9cb36b2d4bca6a0058cd28d578c91c595f20bcc084c73e8802b289191ac41972bc17ae921010e1b05fd307
+  checksum: 62302cf18fd957776401899b0e0ca50387e84f6f9fb4239ac02d922969bd85cc1b3b01f9facc631273ab4c8281aa5a177bff1008b9df936a73f1a9a52b48fefc
   languageName: node
   linkType: hard
 
-"@metamask/snaps-execution-environments@npm:^0.35.2-flask.1":
-  version: 0.35.2-flask.1
-  resolution: "@metamask/snaps-execution-environments@npm:0.35.2-flask.1"
+"@metamask/snaps-execution-environments@npm:^0.36.0-flask.1":
+  version: 0.36.0-flask.1
+  resolution: "@metamask/snaps-execution-environments@npm:0.36.0-flask.1"
   dependencies:
     "@metamask/object-multiplex": ^1.2.0
     "@metamask/post-message-stream": ^6.1.2
     "@metamask/providers": ^11.0.0
-    "@metamask/rpc-methods": ^0.35.2-flask.1
-    "@metamask/snaps-utils": ^0.35.2-flask.1
+    "@metamask/rpc-methods": ^0.36.0-flask.1
+    "@metamask/snaps-utils": ^0.36.0-flask.1
     "@metamask/utils": ^6.0.1
     eth-rpc-errors: ^4.0.3
     json-rpc-engine: ^6.1.0
@@ -1281,7 +1281,7 @@ __metadata:
     ses: ^0.18.1
     stream-browserify: ^3.0.0
     superstruct: ^1.0.3
-  checksum: b112a25a5cd5574fd84dcc7a62b9076d59d0182d52c37645d44477efcb67d18a4dd40bef3778dcbd67009fe3b261ffe0e247def112737a16bac5e86bf16081e7
+  checksum: e21e80ca2acc093a2feae27d16120675346c852ceda4eb86f0706bc521aadcad22fb77922aa579452a075d25cc72b698adf12962cef1b297edca93bf0088194e
   languageName: node
   linkType: hard
 
@@ -1296,19 +1296,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-ui@npm:^0.35.2-flask.1":
-  version: 0.35.2-flask.1
-  resolution: "@metamask/snaps-ui@npm:0.35.2-flask.1"
+"@metamask/snaps-ui@npm:^0.36.0-flask.1":
+  version: 0.36.0-flask.1
+  resolution: "@metamask/snaps-ui@npm:0.36.0-flask.1"
   dependencies:
     "@metamask/utils": ^6.0.1
     superstruct: ^1.0.3
-  checksum: fb272068e04a9d4e0458aecef4df4091a9d9d9c0c3580d40c211a710566eb5610252456f0eb99533379d6d919c0c4156dda1ae6233693723e9227e54a4c5ddbf
+  checksum: 5d26a964b9efd5ae58fc50b887429d319c1ed5b3b69f6ff0908614b9ae221aa962a6e07135313fb07cc712a74302437825e31b47329dcc2aefeef22fe7ae4449
   languageName: node
   linkType: hard
 
-"@metamask/snaps-utils@npm:^0.35.2-flask.1":
-  version: 0.35.2-flask.1
-  resolution: "@metamask/snaps-utils@npm:0.35.2-flask.1"
+"@metamask/snaps-utils@npm:^0.36.0-flask.1":
+  version: 0.36.0-flask.1
+  resolution: "@metamask/snaps-utils@npm:0.36.0-flask.1"
   dependencies:
     "@babel/core": ^7.20.12
     "@babel/types": ^7.18.7
@@ -1317,7 +1317,7 @@ __metadata:
     "@metamask/permission-controller": ^4.0.0
     "@metamask/providers": ^11.0.0
     "@metamask/snaps-registry": ^1.2.1
-    "@metamask/snaps-ui": ^0.35.2-flask.1
+    "@metamask/snaps-ui": ^0.36.0-flask.1
     "@metamask/utils": ^6.0.1
     "@noble/hashes": ^1.3.1
     "@scure/base": ^1.1.1
@@ -1331,7 +1331,7 @@ __metadata:
     ses: ^0.18.1
     superstruct: ^1.0.3
     validate-npm-package-name: ^5.0.0
-  checksum: 4a22bf42512e2bdc944042cb05ef8b8f733ce902c0f374f7d36e22344700a3d0674a48ddacbe096a7e253c24f7ba05cff7ff30a05d3e48a840b63cbeeb46f0ce
+  checksum: 6fa7a6f386500e744b73e388da5f82071a7c469299e79d1e4434a1bc9dd4027e8ae463f9b2d6d41f544c107e80235c4c78e4cdf364df98a97878410e8ac98ae7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR replaces:

- https://github.com/MetaMask/keyring-api/pull/45
- https://github.com/MetaMask/keyring-api/pull/38