### PR TITLE
feat: remove account name from `KeyringAccount` type

### DIFF
--- a/src/KeyringClient.test.ts
+++ b/src/KeyringClient.test.ts
@@ -21,7 +21,6 @@ describe('KeyringClient', () => {
       const expectedResponse: KeyringAccount[] = [
         {
           id: '49116980-0712-4fa5-b045-e4294f1d440e',
-          name: 'Account 1',
           address: '0xE9A74AACd7df8112911ca93260fC5a046f8a64Ae',
           options: {},
           methods: [],
@@ -45,7 +44,6 @@ describe('KeyringClient', () => {
       const id = '49116980-0712-4fa5-b045-e4294f1d440e';
       const expectedResponse = {
         id: '49116980-0712-4fa5-b045-e4294f1d440e',
-        name: 'Account 1',
         address: '0xE9A74AACd7df8112911ca93260fC5a046f8a64Ae',
         options: {},
         methods: [],
@@ -68,7 +66,6 @@ describe('KeyringClient', () => {
     it('should send a request to create an account and return the response', async () => {
       const expectedResponse = {
         id: '49116980-0712-4fa5-b045-e4294f1d440e',
-        name: 'Account 1',
         address: '0xE9A74AACd7df8112911ca93260fC5a046f8a64Ae',
         options: {},
         methods: [],
@@ -76,12 +73,12 @@ describe('KeyringClient', () => {
       };
 
       mockSender.send.mockResolvedValue(expectedResponse);
-      const account = await keyring.createAccount('Account 1');
+      const account = await keyring.createAccount();
       expect(mockSender.send).toHaveBeenCalledWith({
         jsonrpc: '2.0',
         id: expect.any(String),
         method: 'keyring_createAccount',
-        params: { name: 'Account 1', options: {} },
+        params: { options: {} },
       });
       expect(account).toStrictEqual(expectedResponse);
     });
@@ -111,7 +108,6 @@ describe('KeyringClient', () => {
     it('should send a request to update an account', async () => {
       const account: KeyringAccount = {
         id: '49116980-0712-4fa5-b045-e4294f1d440e',
-        name: 'Account 1',
         address: '0xE9A74AACd7df8112911ca93260fC5a046f8a64Ae',
         options: {},
         methods: [],

--- a/src/KeyringClient.ts
+++ b/src/KeyringClient.ts
@@ -77,13 +77,12 @@ export class KeyringClient implements Keyring {
   }
 
   async createAccount(
-    name: string,
     options: Record<string, Json> = {},
   ): Promise<KeyringAccount> {
     return strictMask(
       await this.#send({
         method: 'keyring_createAccount',
-        params: { name, options },
+        params: { options },
       }),
       CreateAccountResponseStruct,
     );

--- a/src/KeyringSnapControllerClient.test.ts
+++ b/src/KeyringSnapControllerClient.test.ts
@@ -9,7 +9,6 @@ describe('KeyringSnapControllerClient', () => {
   const accountsList: KeyringAccount[] = [
     {
       id: '13f94041-6ae6-451f-a0fe-afdd2fda18a7',
-      name: 'Account 1',
       address: '0xE9A74AACd7df8112911ca93260fC5a046f8a64Ae',
       options: {},
       methods: [],

--- a/src/KeyringSnapRpcClient.test.ts
+++ b/src/KeyringSnapRpcClient.test.ts
@@ -9,7 +9,6 @@ describe('KeyringSnapRpcClient', () => {
   const accountsList: KeyringAccount[] = [
     {
       id: '13f94041-6ae6-451f-a0fe-afdd2fda18a7',
-      name: 'Account 1',
       address: '0xE9A74AACd7df8112911ca93260fC5a046f8a64Ae',
       options: {},
       methods: [],

--- a/src/api.ts
+++ b/src/api.ts
@@ -21,11 +21,6 @@ export const KeyringAccountStruct = object({
   id: UuidStruct,
 
   /**
-   * User-chosen account name.
-   */
-  name: string(),
-
-  /**
    * Account address or next receive address (UTXO).
    */
   address: string(),
@@ -136,18 +131,13 @@ export type Keyring = {
   /**
    * Create an account.
    *
-   * Creates a new account with the given name, supported chains, and optional
-   * account options.
+   * Creates a new account with optional, keyring-defined, account options.
    *
-   * @param name - The name of the account.
    * @param options - Keyring-defined options for the account (optional).
    * @returns A promise that resolves to the newly created KeyringAccount
    * object without any private information.
    */
-  createAccount(
-    name: string,
-    options?: Record<string, Json>,
-  ): Promise<KeyringAccount>;
+  createAccount(options?: Record<string, Json>): Promise<KeyringAccount>;
 
   /**
    * Filter supported chains for a given account.

--- a/src/internal-api.ts
+++ b/src/internal-api.ts
@@ -61,7 +61,6 @@ export const CreateAccountRequestStruct = object({
   ...CommonHeader,
   method: literal('keyring_createAccount'),
   params: object({
-    name: string(),
     options: record(string(), JsonStruct),
   }),
 });

--- a/src/rpc-handler.test.ts
+++ b/src/rpc-handler.test.ts
@@ -194,13 +194,13 @@ describe('keyringRpcDispatcher', () => {
       jsonrpc: '2.0',
       id: '7c507ff0-365f-4de0-8cd5-eb83c30ebda4',
       method: 'keyring_createAccount',
-      params: { name: 'account_name', options: {} },
+      params: { options: {} },
     };
 
     keyring.createAccount.mockResolvedValue('CreateAccount result');
     const result = await handleKeyringRequest(keyring, request);
 
-    expect(keyring.createAccount).toHaveBeenCalledWith('account_name', {});
+    expect(keyring.createAccount).toHaveBeenCalledWith({});
     expect(result).toBe('CreateAccount result');
   });
 
@@ -235,7 +235,6 @@ describe('keyringRpcDispatcher', () => {
       params: {
         account: {
           id: '4f983fa2-4f53-4c63-a7c2-f9a5ed750041',
-          name: 'test',
           address: '0x0',
           options: {},
           methods: [],
@@ -249,7 +248,6 @@ describe('keyringRpcDispatcher', () => {
 
     expect(keyring.updateAccount).toHaveBeenCalledWith({
       id: '4f983fa2-4f53-4c63-a7c2-f9a5ed750041',
-      name: 'test',
       address: '0x0',
       options: {},
       methods: [],

--- a/src/rpc-handler.ts
+++ b/src/rpc-handler.ts
@@ -86,10 +86,7 @@ export async function handleKeyringRequest(
 
     case 'keyring_createAccount': {
       assert(request, CreateAccountRequestStruct);
-      return await keyring.createAccount(
-        request.params.name,
-        request.params.options,
-      );
+      return await keyring.createAccount(request.params.options);
     }
 
     case 'keyring_filterAccountChains': {


### PR DESCRIPTION
BREAKING CHANGE: This commit changes the `KeyringAccount` type and the `Keyring` interface.