### PR TITLE
feat: remove versioned `eth_signTypedData` methods

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -32,10 +32,6 @@ export const KeyringAccountStruct = object({
       'eth_sign',
       'eth_signTransaction',
       'eth_signTypedData',
-      'eth_signTypedData_v1',
-      'eth_signTypedData_v2',
-      'eth_signTypedData_v3',
-      'eth_signTypedData_v4',
     ]),
   ),
 


### PR DESCRIPTION
BREAKING CHANGE: This PR removes previously supported versioned `eth_signTypedData` methods. Those methods existed because they were implemented before EIP-712 was final.