### PR TITLE
feat: make `approveRequest` and `rejectRequest` optional

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -202,7 +202,7 @@ export type Keyring = {
    * @returns A promise that resolves when the request is successfully
    * approved.
    */
-  approveRequest(id: string, data?: Record<string, Json>): Promise<void>;
+  approveRequest?(id: string, data?: Record<string, Json>): Promise<void>;
 
   /**
    * Reject a request.
@@ -213,5 +213,5 @@ export type Keyring = {
    * @returns A promise that resolves when the request is successfully
    * rejected.
    */
-  rejectRequest(id: string): Promise<void>;
+  rejectRequest?(id: string): Promise<void>;
 };

--- a/src/rpc-handler.test.ts
+++ b/src/rpc-handler.test.ts
@@ -1,3 +1,4 @@
+import type { Keyring } from './api';
 import type { JsonRpcRequest } from './JsonRpcRequest';
 import {
   MethodNotSupportedError,
@@ -348,6 +349,24 @@ describe('keyringRpcDispatcher', () => {
     expect(result).toBe('ApproveRequest result');
   });
 
+  it('should throw MethodNotSupportedError if approveRequest is not implemented', async () => {
+    const request: JsonRpcRequest = {
+      jsonrpc: '2.0',
+      id: '7c507ff0-365f-4de0-8cd5-eb83c30ebda4',
+      method: 'keyring_approveRequest',
+      params: { id: 'request_id', data: {} },
+    };
+
+    const partialKeyring: Keyring = {
+      ...keyring,
+    };
+    delete partialKeyring.approveRequest;
+
+    await expect(handleKeyringRequest(partialKeyring, request)).rejects.toThrow(
+      MethodNotSupportedError,
+    );
+  });
+
   it('should fail to list requests with a non-UUIDv4 request ID', async () => {
     const request: JsonRpcRequest = {
       jsonrpc: '2.0',
@@ -373,6 +392,24 @@ describe('keyringRpcDispatcher', () => {
 
     expect(keyring.rejectRequest).toHaveBeenCalledWith('request_id');
     expect(result).toBe('RejectRequest result');
+  });
+
+  it('should throw MethodNotSupportedError if rejectRequest is not implemented', async () => {
+    const request: JsonRpcRequest = {
+      jsonrpc: '2.0',
+      id: '7c507ff0-365f-4de0-8cd5-eb83c30ebda4',
+      method: 'keyring_rejectRequest',
+      params: { id: 'request_id' },
+    };
+
+    const partialKeyring: Keyring = {
+      ...keyring,
+    };
+    delete partialKeyring.rejectRequest;
+
+    await expect(handleKeyringRequest(partialKeyring, request)).rejects.toThrow(
+      MethodNotSupportedError,
+    );
   });
 
   it('should throw MethodNotSupportedError for an unknown method', async () => {

--- a/src/rpc-handler.ts
+++ b/src/rpc-handler.ts
@@ -123,6 +123,11 @@ export async function handleKeyringRequest(
     }
 
     case 'keyring_approveRequest': {
+      // This is an optional method, so we have to check if it exists.
+      if (keyring.approveRequest === undefined) {
+        throw new MethodNotSupportedError(request.method);
+      }
+
       assert(request, ApproveRequestRequestStruct);
       return await keyring.approveRequest(
         request.params.id,
@@ -131,6 +136,11 @@ export async function handleKeyringRequest(
     }
 
     case 'keyring_rejectRequest': {
+      // This is an optional method, so we have to check if it exists.
+      if (keyring.rejectRequest === undefined) {
+        throw new MethodNotSupportedError(request.method);
+      }
+
       assert(request, RejectRequestRequestStruct);
       return await keyring.rejectRequest(request.params.id);
     }


### PR DESCRIPTION
This PR makes the `approveRequest` and `rejectRequest` methods optional in the Keyring API.

Rationale: Keyrings that implement a synchonous signature flow don't require those methods to be implemented.