### PR TITLE
refactor: make `exportAccount`, `listRequests` and `getRequest` optional

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -211,7 +211,7 @@ export type Keyring = {
    * @param id - The ID of the account to export.
    * @returns A promise that resolves to the exported account.
    */
-  exportAccount(id: string): Promise<KeyringAccountData>;
+  exportAccount?(id: string): Promise<KeyringAccountData>;
 
   /**
    * List all submitted requests.
@@ -221,7 +221,7 @@ export type Keyring = {
    *
    * @returns A promise that resolves to an array of KeyringRequest objects.
    */
-  listRequests(): Promise<KeyringRequest[]>;
+  listRequests?(): Promise<KeyringRequest[]>;
 
   /**
    * Get a request.
@@ -232,7 +232,7 @@ export type Keyring = {
    * @returns A promise that resolves to the KeyringRequest object if found, or
    * undefined otherwise.
    */
-  getRequest(id: string): Promise<KeyringRequest | undefined>;
+  getRequest?(id: string): Promise<KeyringRequest | undefined>;
 
   /**
    * Submit a request.

--- a/src/rpc-handler.test.ts
+++ b/src/rpc-handler.test.ts
@@ -275,6 +275,44 @@ describe('keyringRpcDispatcher', () => {
     expect(result).toBe('DeleteAccount result');
   });
 
+  it('should call keyring_exportAccount', async () => {
+    const request: JsonRpcRequest = {
+      jsonrpc: '2.0',
+      id: '7c507ff0-365f-4de0-8cd5-eb83c30ebda4',
+      method: 'keyring_exportAccount',
+      params: { id: '4f983fa2-4f53-4c63-a7c2-f9a5ed750041' },
+    };
+    const expected = {
+      privateKey: '0x0123',
+    };
+
+    keyring.exportAccount.mockResolvedValue(expected);
+    const result = await handleKeyringRequest(keyring, request);
+
+    expect(keyring.exportAccount).toHaveBeenCalledWith(
+      '4f983fa2-4f53-4c63-a7c2-f9a5ed750041',
+    );
+    expect(result).toStrictEqual(expected);
+  });
+
+  it('should throw MethodNotSupportedError if exportAccount is not implemented', async () => {
+    const request: JsonRpcRequest = {
+      jsonrpc: '2.0',
+      id: '7c507ff0-365f-4de0-8cd5-eb83c30ebda4',
+      method: 'keyring_exportAccount',
+      params: { id: '4f983fa2-4f53-4c63-a7c2-f9a5ed750041' },
+    };
+
+    const partialKeyring: Keyring = {
+      ...keyring,
+    };
+    delete partialKeyring.exportAccount;
+
+    await expect(handleKeyringRequest(partialKeyring, request)).rejects.toThrow(
+      MethodNotSupportedError,
+    );
+  });
+
   it('should call keyring_listRequests', async () => {
     const request: JsonRpcRequest = {
       jsonrpc: '2.0',
@@ -287,6 +325,23 @@ describe('keyringRpcDispatcher', () => {
 
     expect(keyring.listRequests).toHaveBeenCalled();
     expect(result).toBe('ListRequests result');
+  });
+
+  it('should throw MethodNotSupportedError if listRequests is not implemented', async () => {
+    const request: JsonRpcRequest = {
+      jsonrpc: '2.0',
+      id: '7c507ff0-365f-4de0-8cd5-eb83c30ebda4',
+      method: 'keyring_listRequests',
+    };
+
+    const partialKeyring: Keyring = {
+      ...keyring,
+    };
+    delete partialKeyring.listRequests;
+
+    await expect(handleKeyringRequest(partialKeyring, request)).rejects.toThrow(
+      MethodNotSupportedError,
+    );
   });
 
   it('should call keyring_getRequest', async () => {
@@ -302,6 +357,24 @@ describe('keyringRpcDispatcher', () => {
 
     expect(keyring.getRequest).toHaveBeenCalledWith('request_id');
     expect(result).toBe('GetRequest result');
+  });
+
+  it('should throw MethodNotSupportedError if getRequest is not implemented', async () => {
+    const request: JsonRpcRequest = {
+      jsonrpc: '2.0',
+      id: '7c507ff0-365f-4de0-8cd5-eb83c30ebda4',
+      method: 'keyring_getRequest',
+      params: { id: 'request_id' },
+    };
+
+    const partialKeyring: Keyring = {
+      ...keyring,
+    };
+    delete partialKeyring.getRequest;
+
+    await expect(handleKeyringRequest(partialKeyring, request)).rejects.toThrow(
+      MethodNotSupportedError,
+    );
   });
 
   it('should call keyring_submitRequest', async () => {

--- a/src/rpc-handler.ts
+++ b/src/rpc-handler.ts
@@ -8,6 +8,7 @@ import {
   CreateAccountRequestStruct,
   ApproveRequestRequestStruct,
   DeleteAccountRequestStruct,
+  ExportAccountRequestStruct,
   GetRequestRequestStruct,
   RejectRequestRequestStruct,
   SubmitRequestRequestStruct,
@@ -58,6 +59,21 @@ export function buildHandlersChain(
   };
 }
 
+export enum KeyringRpcMethod {
+  ListAccounts = 'keyring_listAccounts',
+  GetAccount = 'keyring_getAccount',
+  CreateAccount = 'keyring_createAccount',
+  FilterAccountChains = 'keyring_filterAccountChains',
+  UpdateAccount = 'keyring_updateAccount',
+  DeleteAccount = 'keyring_deleteAccount',
+  ExportAccount = 'keyring_exportAccount',
+  ListRequests = 'keyring_listRequests',
+  GetRequest = 'keyring_getRequest',
+  SubmitRequest = 'keyring_submitRequest',
+  ApproveRequest = 'keyring_approveRequest',
+  RejectRequest = 'keyring_rejectRequest',
+}
+
 /**
  * Handles a keyring JSON-RPC request.
  *
@@ -74,75 +90,82 @@ export async function handleKeyringRequest(
   assert(request, JsonRpcRequestStruct);
 
   switch (request.method) {
-    case 'keyring_listAccounts': {
+    case KeyringRpcMethod.ListAccounts: {
       assert(request, ListAccountsRequestStruct);
-      return await keyring.listAccounts();
+      return keyring.listAccounts();
     }
 
-    case 'keyring_getAccount': {
+    case KeyringRpcMethod.GetAccount: {
       assert(request, GetAccountRequestStruct);
-      return await keyring.getAccount(request.params.id);
+      return keyring.getAccount(request.params.id);
     }
 
-    case 'keyring_createAccount': {
+    case KeyringRpcMethod.CreateAccount: {
       assert(request, CreateAccountRequestStruct);
-      return await keyring.createAccount(request.params.options);
+      return keyring.createAccount(request.params.options);
     }
 
-    case 'keyring_filterAccountChains': {
+    case KeyringRpcMethod.FilterAccountChains: {
       assert(request, FilterAccountChainsStruct);
-      return await keyring.filterAccountChains(
+      return keyring.filterAccountChains(
         request.params.id,
         request.params.chains,
       );
     }
 
-    case 'keyring_updateAccount': {
+    case KeyringRpcMethod.UpdateAccount: {
       assert(request, UpdateAccountRequestStruct);
-      return await keyring.updateAccount(request.params.account);
+      return keyring.updateAccount(request.params.account);
     }
 
-    case 'keyring_deleteAccount': {
+    case KeyringRpcMethod.DeleteAccount: {
       assert(request, DeleteAccountRequestStruct);
-      return await keyring.deleteAccount(request.params.id);
+      return keyring.deleteAccount(request.params.id);
     }
 
-    case 'keyring_listRequests': {
+    case KeyringRpcMethod.ExportAccount: {
+      if (keyring.exportAccount === undefined) {
+        throw new MethodNotSupportedError(request.method);
+      }
+      assert(request, ExportAccountRequestStruct);
+      return keyring.exportAccount(request.params.id);
+    }
+
+    case KeyringRpcMethod.ListRequests: {
+      if (keyring.listRequests === undefined) {
+        throw new MethodNotSupportedError(request.method);
+      }
       assert(request, ListRequestsRequestStruct);
-      return await keyring.listRequests();
+      return keyring.listRequests();
     }
 
-    case 'keyring_getRequest': {
+    case KeyringRpcMethod.GetRequest: {
+      if (keyring.getRequest === undefined) {
+        throw new MethodNotSupportedError(request.method);
+      }
       assert(request, GetRequestRequestStruct);
-      return await keyring.getRequest(request.params.id);
+      return keyring.getRequest(request.params.id);
     }
 
-    case 'keyring_submitRequest': {
+    case KeyringRpcMethod.SubmitRequest: {
       assert(request, SubmitRequestRequestStruct);
-      return await keyring.submitRequest(request.params);
+      return keyring.submitRequest(request.params);
     }
 
-    case 'keyring_approveRequest': {
-      // This is an optional method, so we have to check if it exists.
+    case KeyringRpcMethod.ApproveRequest: {
       if (keyring.approveRequest === undefined) {
         throw new MethodNotSupportedError(request.method);
       }
-
       assert(request, ApproveRequestRequestStruct);
-      return await keyring.approveRequest(
-        request.params.id,
-        request.params.data,
-      );
+      return keyring.approveRequest(request.params.id, request.params.data);
     }
 
-    case 'keyring_rejectRequest': {
-      // This is an optional method, so we have to check if it exists.
+    case KeyringRpcMethod.RejectRequest: {
       if (keyring.rejectRequest === undefined) {
         throw new MethodNotSupportedError(request.method);
       }
-
       assert(request, RejectRequestRequestStruct);
-      return await keyring.rejectRequest(request.params.id);
+      return keyring.rejectRequest(request.params.id);
     }
 
     default: {


### PR DESCRIPTION
The async transaction flow shouldn't require snaps to implement the `listRequests` and `getRequest` methods, so we are making them optional.

Also, the `exportAccount` may not be supported by all snaps, so it doesn't make sense to force its implementation.

We decided to keep the CRUD account management methods mandatory, since they are (or will be) directly called by MetaMask.