### PR TITLE
feat: add keyring events and helper functions

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -8,15 +8,6 @@ logFilters:
 
 nodeLinker: node-modules
 
-npmRegistries:
-  'https://npm.pkg.github.com':
-    npmAlwaysAuth: true
-    npmAuthToken: '${NPM_TOKEN-}'
-
-npmScopes:
-  metamask:
-    npmRegistryServer: '${METAMASK_NPM_REGISTRY:-https://registry.yarnpkg.com}'
-
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-allow-scripts.cjs
     spec: "https://raw.githubusercontent.com/LavaMoat/LavaMoat/main/packages/yarn-plugin-allow-scripts/bundles/@yarnpkg/plugin-allow-scripts.js"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -8,6 +8,15 @@ logFilters:
 
 nodeLinker: node-modules
 
+npmRegistries:
+  'https://npm.pkg.github.com':
+    npmAlwaysAuth: true
+    npmAuthToken: '${NPM_TOKEN-}'
+
+npmScopes:
+  metamask:
+    npmRegistryServer: '${METAMASK_NPM_REGISTRY:-https://registry.yarnpkg.com}'
+
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-allow-scripts.cjs
     spec: "https://raw.githubusercontent.com/LavaMoat/LavaMoat/main/packages/yarn-plugin-allow-scripts/bundles/@yarnpkg/plugin-allow-scripts.js"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@metamask/providers": "^11.0.0",
+    "@metamask/rpc-methods": "0.38.0-preview.6331907",
     "@metamask/snaps-controllers": "^0.38.1-flask.1",
     "@metamask/snaps-utils": "^0.38.1-flask.1",
     "@metamask/utils": "^7.0.0",
@@ -91,7 +92,9 @@
       "@metamask/snaps-utils>@metamask/base-controller>@metamask/controller-utils>ethereumjs-util>ethereum-cryptography>keccak": false,
       "@metamask/snaps-utils>@metamask/base-controller>@metamask/controller-utils>ethereumjs-util>ethereum-cryptography>secp256k1": false,
       "@metamask/snaps-utils>@metamask/permission-controller>@metamask/controller-utils>ethereumjs-util>ethereum-cryptography>keccak": false,
-      "@metamask/snaps-utils>@metamask/permission-controller>@metamask/controller-utils>ethereumjs-util>ethereum-cryptography>secp256k1": false
+      "@metamask/snaps-utils>@metamask/permission-controller>@metamask/controller-utils>ethereumjs-util>ethereum-cryptography>secp256k1": false,
+      "@metamask/rpc-methods>@metamask/permission-controller>@metamask/controller-utils>ethereumjs-util>ethereum-cryptography>keccak": false,
+      "@metamask/rpc-methods>@metamask/permission-controller>@metamask/controller-utils>ethereumjs-util>ethereum-cryptography>secp256k1": false
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
   },
   "dependencies": {
     "@metamask/providers": "^11.0.0",
-    "@metamask/rpc-methods": "0.38.0-preview.6331907",
-    "@metamask/snaps-controllers": "^0.38.1-flask.1",
-    "@metamask/snaps-utils": "^0.38.1-flask.1",
+    "@metamask/rpc-methods": "^0.38.1-flask.1",
+    "@metamask/snaps-controllers": "^0.38.2-flask.1",
+    "@metamask/snaps-utils": "^0.38.2-flask.1",
     "@metamask/utils": "^7.0.0",
     "@types/uuid": "^9.0.1",
     "superstruct": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
   },
   "dependencies": {
     "@metamask/providers": "^11.0.0",
-    "@metamask/snaps-controllers": "^0.38.0-flask.1",
-    "@metamask/snaps-utils": "^0.38.0-flask.1",
+    "@metamask/snaps-controllers": "^0.38.1-flask.1",
+    "@metamask/snaps-utils": "^0.38.1-flask.1",
     "@metamask/utils": "^7.0.0",
     "@types/uuid": "^9.0.1",
     "superstruct": "^1.0.3",

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,0 +1,74 @@
+import { JsonStruct } from '@metamask/utils';
+import { literal, object } from 'superstruct';
+
+import { KeyringAccountStruct } from './api';
+import { UuidStruct } from './utils';
+
+/**
+ * Supported keyring events.
+ */
+export enum KeyringEvent {
+  // Account events
+  AccountCreated = 'event:accountCreated',
+  AccountUpdated = 'event:accountUpdated',
+  AccountDeleted = 'event:accountDeleted',
+
+  // Request events
+  RequestApproved = 'event:requestApproved',
+  RequestRejected = 'event:requestRejected',
+}
+
+export const AccountCreatedEventStruct = object({
+  method: literal<string>(KeyringEvent.AccountCreated),
+  params: object({
+    /**
+     * New account object.
+     */
+    account: KeyringAccountStruct,
+  }),
+});
+
+export const AccountUpdatedEventStruct = object({
+  method: literal<string>(KeyringEvent.AccountUpdated),
+  params: object({
+    /**
+     * Updated account object.
+     */
+    account: KeyringAccountStruct,
+  }),
+});
+
+export const AccountDeletedEventStruct = object({
+  method: literal<string>(KeyringEvent.AccountDeleted),
+  params: object({
+    /**
+     * Deleted account ID.
+     */
+    id: UuidStruct,
+  }),
+});
+
+export const RequestApprovedEventStruct = object({
+  method: literal<string>(KeyringEvent.RequestApproved),
+  params: object({
+    /**
+     * Request ID.
+     */
+    id: UuidStruct,
+
+    /**
+     * Request result.
+     */
+    result: JsonStruct,
+  }),
+});
+
+export const RequestRejectedEventStruct = object({
+  method: literal<string>(KeyringEvent.RequestRejected),
+  params: object({
+    /**
+     * Request ID.
+     */
+    id: UuidStruct,
+  }),
+});

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,9 +1,3 @@
-import { JsonStruct } from '@metamask/utils';
-import { literal, object } from 'superstruct';
-
-import { KeyringAccountStruct } from './api';
-import { UuidStruct } from './utils';
-
 /**
  * Supported keyring events.
  */
@@ -17,58 +11,3 @@ export enum KeyringEvent {
   RequestApproved = 'event:requestApproved',
   RequestRejected = 'event:requestRejected',
 }
-
-export const AccountCreatedEventStruct = object({
-  method: literal<string>(KeyringEvent.AccountCreated),
-  params: object({
-    /**
-     * New account object.
-     */
-    account: KeyringAccountStruct,
-  }),
-});
-
-export const AccountUpdatedEventStruct = object({
-  method: literal<string>(KeyringEvent.AccountUpdated),
-  params: object({
-    /**
-     * Updated account object.
-     */
-    account: KeyringAccountStruct,
-  }),
-});
-
-export const AccountDeletedEventStruct = object({
-  method: literal<string>(KeyringEvent.AccountDeleted),
-  params: object({
-    /**
-     * Deleted account ID.
-     */
-    id: UuidStruct,
-  }),
-});
-
-export const RequestApprovedEventStruct = object({
-  method: literal<string>(KeyringEvent.RequestApproved),
-  params: object({
-    /**
-     * Request ID.
-     */
-    id: UuidStruct,
-
-    /**
-     * Request result.
-     */
-    result: JsonStruct,
-  }),
-});
-
-export const RequestRejectedEventStruct = object({
-  method: literal<string>(KeyringEvent.RequestRejected),
-  params: object({
-    /**
-     * Request ID.
-     */
-    id: UuidStruct,
-  }),
-});

--- a/src/internal/events.test.ts
+++ b/src/internal/events.test.ts
@@ -1,0 +1,174 @@
+import { is } from 'superstruct';
+
+import {
+  AccountCreatedEventStruct,
+  AccountDeletedEventStruct,
+  AccountUpdatedEventStruct,
+  RequestApprovedEventStruct,
+  RequestRejectedEventStruct,
+} from './events';
+import { EthAccountType } from '../api';
+import { KeyringEvent } from '../events';
+
+describe('events', () => {
+  describe('AccountCreatedEventStruct', () => {
+    it('should be a valid accountCreated event', () => {
+      const event = {
+        method: KeyringEvent.AccountCreated,
+        params: {
+          account: {
+            id: '11027d05-12f8-4ec0-b03f-151d86a8089e',
+            address: '0x0123',
+            methods: [],
+            options: {},
+            type: EthAccountType.Eoa,
+          },
+        },
+      };
+
+      expect(is(event, AccountCreatedEventStruct)).toBe(true);
+    });
+
+    it('should be an invalid accountCreated event (invalid account id)', () => {
+      const event = {
+        method: KeyringEvent.AccountCreated,
+        params: {
+          account: {
+            id: 'not-a-uuid',
+            address: '0x0123',
+            methods: [],
+            options: {},
+            type: EthAccountType.Eoa,
+          },
+        },
+      };
+
+      expect(is(event, AccountCreatedEventStruct)).toBe(false);
+    });
+  });
+
+  describe('AccountUpdatedEventStruct', () => {
+    it('should be a valid accountUpdated event', () => {
+      const event = {
+        method: KeyringEvent.AccountUpdated,
+        params: {
+          account: {
+            id: '11027d05-12f8-4ec0-b03f-151d86a8089e',
+            address: '0x0123',
+            methods: [],
+            options: {},
+            type: EthAccountType.Eoa,
+          },
+        },
+      };
+
+      expect(is(event, AccountUpdatedEventStruct)).toBe(true);
+    });
+
+    it('should be an invalid accountUpdated event (invalid account id)', () => {
+      const event = {
+        method: KeyringEvent.AccountUpdated,
+        params: {
+          account: {
+            id: 'not-a-uuid',
+            address: '0x0123',
+            methods: [],
+            options: {},
+            type: EthAccountType.Eoa,
+          },
+        },
+      };
+
+      expect(is(event, AccountUpdatedEventStruct)).toBe(false);
+    });
+  });
+
+  describe('AccountDeletedEventStruct', () => {
+    it('should be a valid accountDeleted event', () => {
+      const event = {
+        method: KeyringEvent.AccountDeleted,
+        params: {
+          id: '11027d05-12f8-4ec0-b03f-151d86a8089e',
+        },
+      };
+
+      expect(is(event, AccountDeletedEventStruct)).toBe(true);
+    });
+
+    it('should be an invalid accountDeleted event (invalid account id)', () => {
+      const event = {
+        method: KeyringEvent.AccountDeleted,
+        params: {
+          id: 'not-a-uuid',
+        },
+      };
+
+      expect(is(event, AccountDeletedEventStruct)).toBe(false);
+    });
+  });
+
+  describe('RequestApprovedEventStruct', () => {
+    it('should be a valid requestApproved event', () => {
+      const event = {
+        method: KeyringEvent.RequestApproved,
+        params: {
+          id: '10423e09-c282-4d4c-8b61-3ca071a32e54',
+          result: {
+            signature: '0x0123',
+          },
+        },
+      };
+
+      expect(is(event, RequestApprovedEventStruct)).toBe(true);
+    });
+
+    it('should be an invalid requestApproved event (invalid request id)', () => {
+      const event = {
+        method: KeyringEvent.RequestApproved,
+        params: {
+          id: 'not-a-uuid',
+          result: {
+            signature: '0x0123',
+          },
+        },
+      };
+
+      expect(is(event, RequestApprovedEventStruct)).toBe(false);
+    });
+
+    it('should be an invalid requestApproved event (missing result)', () => {
+      const event = {
+        method: KeyringEvent.RequestApproved,
+        params: {
+          id: 'not-a-uuid',
+        },
+      };
+
+      expect(is(event, RequestApprovedEventStruct)).toBe(false);
+    });
+  });
+
+  describe('RequestRejectedEventStruct', () => {
+    it('should be a valid requestRejected event', () => {
+      const event = {
+        method: KeyringEvent.RequestRejected,
+        params: {
+          id: '10423e09-c282-4d4c-8b61-3ca071a32e54',
+        },
+      };
+
+      expect(is(event, RequestRejectedEventStruct)).toBe(true);
+    });
+
+    it('should be an invalid requestRejected event (invalid request id)', () => {
+      const event = {
+        method: KeyringEvent.RequestRejected,
+        params: {
+          id: 'not-a-uuid',
+        },
+      };
+
+      expect(is(event, RequestRejectedEventStruct)).toBe(false);
+    });
+  });
+});

--- a/src/internal/events.ts
+++ b/src/internal/events.ts
@@ -6,7 +6,7 @@ import { KeyringEvent } from '../events';
 import { UuidStruct } from '../utils';
 
 export const AccountCreatedEventStruct = object({
-  method: literal<string>(KeyringEvent.AccountCreated),
+  method: literal(`${KeyringEvent.AccountCreated}`),
   params: object({
     /**
      * New account object.
@@ -16,7 +16,7 @@ export const AccountCreatedEventStruct = object({
 });
 
 export const AccountUpdatedEventStruct = object({
-  method: literal<string>(KeyringEvent.AccountUpdated),
+  method: literal(`${KeyringEvent.AccountUpdated}`),
   params: object({
     /**
      * Updated account object.
@@ -26,7 +26,7 @@ export const AccountUpdatedEventStruct = object({
 });
 
 export const AccountDeletedEventStruct = object({
-  method: literal<string>(KeyringEvent.AccountDeleted),
+  method: literal(`${KeyringEvent.AccountDeleted}`),
   params: object({
     /**
      * Deleted account ID.
@@ -36,7 +36,7 @@ export const AccountDeletedEventStruct = object({
 });
 
 export const RequestApprovedEventStruct = object({
-  method: literal<string>(KeyringEvent.RequestApproved),
+  method: literal(`${KeyringEvent.RequestApproved}`),
   params: object({
     /**
      * Request ID.
@@ -51,7 +51,7 @@ export const RequestApprovedEventStruct = object({
 });
 
 export const RequestRejectedEventStruct = object({
-  method: literal<string>(KeyringEvent.RequestRejected),
+  method: literal(`${KeyringEvent.RequestRejected}`),
   params: object({
     /**
      * Request ID.

--- a/src/internal/events.ts
+++ b/src/internal/events.ts
@@ -1,0 +1,61 @@
+import { JsonStruct } from '@metamask/utils';
+import { literal, object } from 'superstruct';
+
+import { KeyringAccountStruct } from '../api';
+import { KeyringEvent } from '../events';
+import { UuidStruct } from '../utils';
+
+export const AccountCreatedEventStruct = object({
+  method: literal<string>(KeyringEvent.AccountCreated),
+  params: object({
+    /**
+     * New account object.
+     */
+    account: KeyringAccountStruct,
+  }),
+});
+
+export const AccountUpdatedEventStruct = object({
+  method: literal<string>(KeyringEvent.AccountUpdated),
+  params: object({
+    /**
+     * Updated account object.
+     */
+    account: KeyringAccountStruct,
+  }),
+});
+
+export const AccountDeletedEventStruct = object({
+  method: literal<string>(KeyringEvent.AccountDeleted),
+  params: object({
+    /**
+     * Deleted account ID.
+     */
+    id: UuidStruct,
+  }),
+});
+
+export const RequestApprovedEventStruct = object({
+  method: literal<string>(KeyringEvent.RequestApproved),
+  params: object({
+    /**
+     * Request ID.
+     */
+    id: UuidStruct,
+
+    /**
+     * Request result.
+     */
+    result: JsonStruct,
+  }),
+});
+
+export const RequestRejectedEventStruct = object({
+  method: literal<string>(KeyringEvent.RequestRejected),
+  params: object({
+    /**
+     * Request ID.
+     */
+    id: UuidStruct,
+  }),
+});

--- a/src/snap-utils.test.ts
+++ b/src/snap-utils.test.ts
@@ -1,0 +1,22 @@
+import { KeyringEvent } from './events';
+import { emitSnapKeyringEvent } from './snap-utils';
+
+describe('emitSnapKeyringEvent', () => {
+  it('should call snap.request with the correct parameters', async () => {
+    const snap = {
+      request: jest.fn(),
+    };
+    const event = KeyringEvent.AccountDeleted;
+    const data = { id: 'ffa9836a-8fe4-48a2-8f0f-95d08d8c1e87' };
+
+    await emitSnapKeyringEvent(snap, event, data);
+
+    expect(snap.request).toHaveBeenCalledWith({
+      method: 'snap_manageAccounts',
+      params: {
+        method: event,
+        params: data,
+      },
+    });
+  });
+});

--- a/src/snap-utils.ts
+++ b/src/snap-utils.ts
@@ -1,0 +1,25 @@
+import type { SnapsGlobalObject } from '@metamask/rpc-methods';
+import type { Json } from '@metamask/utils';
+
+import type { KeyringEvent } from './events';
+
+/**
+ * Emit a keyring event from a snap.
+ *
+ * @param snap - The global snap object.
+ * @param event - The event name.
+ * @param data - The event data.
+ */
+export async function emitSnapKeyringEvent(
+  snap: SnapsGlobalObject,
+  event: KeyringEvent,
+  data: Record<string, Json>,
+): Promise<void> {
+  await snap.request({
+    method: 'snap_manageAccounts',
+    params: {
+      method: event,
+      params: { ...data },
+    },
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -980,7 +980,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/approval-controller@npm:^3.0.0":
+"@metamask/approval-controller@npm:^3.0.0, @metamask/approval-controller@npm:^3.5.0":
   version: 3.5.0
   resolution: "@metamask/approval-controller@npm:3.5.0"
   dependencies:
@@ -1029,6 +1029,22 @@ __metadata:
     ethjs-unit: ^0.1.6
     fast-deep-equal: ^3.1.3
   checksum: 3efdaf9b0c9f6d3bb633eeb926e78bedd637b0e042bb1e3974b9829e38456709a2f26d02405499934239351be8bff1854e267df8d0a522738d630bac0aadb732
+  languageName: node
+  linkType: hard
+
+"@metamask/controller-utils@npm:^4.3.0":
+  version: 4.3.1
+  resolution: "@metamask/controller-utils@npm:4.3.1"
+  dependencies:
+    "@metamask/eth-query": ^3.0.1
+    "@metamask/utils": ^6.2.0
+    "@spruceid/siwe-parser": 1.1.3
+    eth-ens-namehash: ^2.0.8
+    eth-rpc-errors: ^4.0.2
+    ethereumjs-util: ^7.0.10
+    ethjs-unit: ^0.1.6
+    fast-deep-equal: ^3.1.3
+  checksum: 5bb471df560a12fba1b7fa147fe0332e06b527637c04facff1774b1279dd388b4cf1d74340469adb13551c08cc156f204d90e36599ad69b54716b11e5842b348
   languageName: node
   linkType: hard
 
@@ -1082,6 +1098,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/eth-query@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@metamask/eth-query@npm:3.0.1"
+  dependencies:
+    json-rpc-random-id: ^1.0.0
+    xtend: ^4.0.1
+  checksum: b9a323dff67328eace7d54fc8b0bc4dd763bf15760870656cbd5aad5380d1ee4489fb5c59506290d5f77cf55e74e530ee97b52702a329f1090ec03a6158434b7
+  languageName: node
+  linkType: hard
+
 "@metamask/key-tree@npm:^9.0.0":
   version: 9.0.0
   resolution: "@metamask/key-tree@npm:9.0.0"
@@ -1108,8 +1134,8 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/providers": ^11.0.0
-    "@metamask/snaps-controllers": ^0.38.0-flask.1
-    "@metamask/snaps-utils": ^0.38.0-flask.1
+    "@metamask/snaps-controllers": ^0.38.1-flask.1
+    "@metamask/snaps-utils": ^0.38.1-flask.1
     "@metamask/utils": ^7.0.0
     "@types/jest": ^28.1.6
     "@types/node": ^16
@@ -1170,6 +1196,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/permission-controller@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@metamask/permission-controller@npm:4.1.0"
+  dependencies:
+    "@metamask/approval-controller": ^3.5.0
+    "@metamask/base-controller": ^3.2.0
+    "@metamask/controller-utils": ^4.3.0
+    "@metamask/utils": ^6.2.0
+    "@types/deep-freeze-strict": ^1.1.0
+    deep-freeze-strict: ^1.1.1
+    eth-rpc-errors: ^4.0.2
+    immer: ^9.0.6
+    json-rpc-engine: ^6.1.0
+    nanoid: ^3.1.31
+  peerDependencies:
+    "@metamask/approval-controller": ^3.5.0
+  checksum: dc0a78321d1331070eb3775928c4c0b0138515c6449c09a73c2243ca8d55801f5a97c4ce2229cdbf630d1a893ec373474d8c17cb35e06c26b0d5ea490c402c48
+  languageName: node
+  linkType: hard
+
 "@metamask/post-message-stream@npm:^6.1.2":
   version: 6.1.2
   resolution: "@metamask/post-message-stream@npm:6.1.2"
@@ -1216,6 +1262,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/rpc-methods@npm:^0.38.0-flask.1":
+  version: 0.38.0-flask.1
+  resolution: "@metamask/rpc-methods@npm:0.38.0-flask.1"
+  dependencies:
+    "@metamask/key-tree": ^9.0.0
+    "@metamask/permission-controller": ^4.1.0
+    "@metamask/snaps-ui": ^0.37.3-flask.1
+    "@metamask/snaps-utils": ^0.38.1-flask.1
+    "@metamask/types": ^1.1.0
+    "@metamask/utils": ^6.0.1
+    "@noble/hashes": ^1.3.1
+    eth-rpc-errors: ^4.0.3
+    superstruct: ^1.0.3
+  checksum: b9b92c3a1da650b65189cf9dc4a59b17916d0ac21b38dcb68ac4ea048b8b5a98e513e6a72aab114cd1faf8907ed0603908569a9cafec36ff9e6e170ae2630c1e
+  languageName: node
+  linkType: hard
+
 "@metamask/safe-event-emitter@npm:^2.0.0":
   version: 2.0.0
   resolution: "@metamask/safe-event-emitter@npm:2.0.0"
@@ -1240,23 +1303,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-controllers@npm:^0.38.0-flask.1":
-  version: 0.38.0-flask.1
-  resolution: "@metamask/snaps-controllers@npm:0.38.0-flask.1"
+"@metamask/snaps-controllers@npm:^0.38.1-flask.1":
+  version: 0.38.1-flask.1
+  resolution: "@metamask/snaps-controllers@npm:0.38.1-flask.1"
   dependencies:
-    "@metamask/approval-controller": ^3.0.0
-    "@metamask/base-controller": ^3.0.0
+    "@metamask/approval-controller": ^3.5.0
+    "@metamask/base-controller": ^3.2.0
     "@metamask/object-multiplex": ^1.2.0
-    "@metamask/permission-controller": ^4.0.0
+    "@metamask/permission-controller": ^4.1.0
     "@metamask/post-message-stream": ^6.1.2
-    "@metamask/rpc-methods": ^0.37.2-flask.1
-    "@metamask/snaps-execution-environments": ^0.38.0-flask.1
+    "@metamask/rpc-methods": ^0.38.0-flask.1
+    "@metamask/snaps-execution-environments": ^0.38.1-flask.1
     "@metamask/snaps-registry": ^1.2.1
-    "@metamask/snaps-utils": ^0.38.0-flask.1
+    "@metamask/snaps-utils": ^0.38.1-flask.1
     "@metamask/utils": ^6.0.1
     "@xstate/fsm": ^2.0.0
     concat-stream: ^2.0.0
-    cron-parser: ^4.5.0
     eth-rpc-errors: ^4.0.3
     gunzip-maybe: ^1.4.2
     immer: ^9.0.6
@@ -1266,13 +1328,13 @@ __metadata:
     pump: ^3.0.0
     readable-web-to-node-stream: ^3.0.2
     tar-stream: ^2.2.0
-  checksum: 538d2fc5295f094d5852c8385b99c60daf3874628f6627926b10412a309d86a7ee3e5bcb61f8c3fdd40b403d6ea08795aa2d338271924c36c6204d65adfcacd6
+  checksum: 40efc1d2d2804140b58c6fabe1bd957d807e6669f28cff3680835d66f3db305defd09f5be21d4134569c51690e31cb1a940294dd65b26c35b088bbf9747eb48a
   languageName: node
   linkType: hard
 
-"@metamask/snaps-execution-environments@npm:^0.38.0-flask.1":
-  version: 0.38.0-flask.1
-  resolution: "@metamask/snaps-execution-environments@npm:0.38.0-flask.1"
+"@metamask/snaps-execution-environments@npm:^0.38.1-flask.1":
+  version: 0.38.1-flask.1
+  resolution: "@metamask/snaps-execution-environments@npm:0.38.1-flask.1"
   dependencies:
     "@metamask/object-multiplex": ^1.2.0
     "@metamask/post-message-stream": ^6.1.2
@@ -1284,10 +1346,9 @@ __metadata:
     json-rpc-engine: ^6.1.0
     nanoid: ^3.1.31
     pump: ^3.0.0
-    ses: ^0.18.1
     stream-browserify: ^3.0.0
     superstruct: ^1.0.3
-  checksum: 725163d03c3c17d0a67ad5829adf69da8bcd2d3890efd984ff5954a19aeeeb4e024a96810d9ae9d5f095f1e39965376f62d41637ff61c59519f46c093f05b0f9
+  checksum: 087e8ecc2b8826b79316f21cd9b1cb359d61586d35590d3c8fc8b11e63a9f23d225ae2019d8055132591907b93994a1e1616d5ebf030db7cd4657b3bbd6e3ea6
   languageName: node
   linkType: hard
 
@@ -1379,6 +1440,35 @@ __metadata:
     superstruct: ^1.0.3
     validate-npm-package-name: ^5.0.0
   checksum: 9b79feabcf3a99f0faa53c87711e0de155807d49dd3a9117933b9636d529fa3f3449bd563535f056fc7cbb3eaffcd9e9703b02985bdb6cfdc090d096d76dad8e
+  languageName: node
+  linkType: hard
+
+"@metamask/snaps-utils@npm:^0.38.1-flask.1":
+  version: 0.38.1-flask.1
+  resolution: "@metamask/snaps-utils@npm:0.38.1-flask.1"
+  dependencies:
+    "@babel/core": ^7.20.12
+    "@babel/types": ^7.18.7
+    "@metamask/base-controller": ^3.2.0
+    "@metamask/key-tree": ^9.0.0
+    "@metamask/permission-controller": ^4.1.0
+    "@metamask/snaps-registry": ^1.2.1
+    "@metamask/snaps-ui": ^0.37.3-flask.1
+    "@metamask/utils": ^6.0.1
+    "@noble/hashes": ^1.3.1
+    "@scure/base": ^1.1.1
+    chalk: ^4.1.2
+    cron-parser: ^4.5.0
+    eth-rpc-errors: ^4.0.3
+    fast-deep-equal: ^3.1.3
+    fast-json-stable-stringify: ^2.1.0
+    is-svg: ^4.4.0
+    rfdc: ^1.3.0
+    semver: ^7.5.4
+    ses: ^0.18.7
+    superstruct: ^1.0.3
+    validate-npm-package-name: ^5.0.0
+  checksum: b968227cce2b570d2f6a205c9a276478edd27ae858679d2a52b56cdb607fb4256d0c773a2a90d3685138d2203b80870be85c924b7ccfc83d737217e9c42cefb8
   languageName: node
   linkType: hard
 
@@ -5552,6 +5642,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-rpc-random-id@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "json-rpc-random-id@npm:1.0.1"
+  checksum: fcd2e884193a129ace4002bd65a86e9cdb206733b4693baea77bd8b372cf8de3043fbea27716a2c9a716581a908ca8d978d9dfec4847eb2cf77edb4cf4b2252c
+  languageName: node
+  linkType: hard
+
 "json-schema-traverse@npm:^0.4.1":
   version: 0.4.1
   resolution: "json-schema-traverse@npm:0.4.1"
@@ -6975,7 +7072,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ses@npm:^0.18.1":
+"ses@npm:^0.18.1, ses@npm:^0.18.7":
   version: 0.18.7
   resolution: "ses@npm:0.18.7"
   dependencies:
@@ -7997,7 +8094,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xtend@npm:~4.0.1":
+"xtend@npm:^4.0.1, xtend@npm:~4.0.1":
   version: 4.0.2
   resolution: "xtend@npm:4.0.2"
   checksum: ac5dfa738b21f6e7f0dd6e65e1b3155036d68104e67e5d5d1bde74892e327d7e5636a076f625599dc394330a731861e87343ff184b0047fef1360a7ec0a5a36a

--- a/yarn.lock
+++ b/yarn.lock
@@ -980,7 +980,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/approval-controller@npm:^3.0.0, @metamask/approval-controller@npm:^3.5.0":
+"@metamask/approval-controller@npm:^3.5.0":
   version: 3.5.0
   resolution: "@metamask/approval-controller@npm:3.5.0"
   dependencies:
@@ -1014,21 +1014,6 @@ __metadata:
     "@metamask/utils": ^6.2.0
     immer: ^9.0.6
   checksum: 3be6f2594309c013e07f83c4bb8271e1e99f02b6ff829c18b5e7218fbab4e6a9e03bcb49056704ce47f84ae2f38b1bc1c10284ec538aad56ed7b554ef2d3e189
-  languageName: node
-  linkType: hard
-
-"@metamask/controller-utils@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@metamask/controller-utils@npm:4.0.0"
-  dependencies:
-    "@metamask/utils": ^5.0.2
-    "@spruceid/siwe-parser": 1.1.3
-    eth-ens-namehash: ^2.0.8
-    eth-rpc-errors: ^4.0.2
-    ethereumjs-util: ^7.0.10
-    ethjs-unit: ^0.1.6
-    fast-deep-equal: ^3.1.3
-  checksum: 3efdaf9b0c9f6d3bb633eeb926e78bedd637b0e042bb1e3974b9829e38456709a2f26d02405499934239351be8bff1854e267df8d0a522738d630bac0aadb732
   languageName: node
   linkType: hard
 
@@ -1134,6 +1119,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/providers": ^11.0.0
+    "@metamask/rpc-methods": 0.38.0-preview.6331907
     "@metamask/snaps-controllers": ^0.38.1-flask.1
     "@metamask/snaps-utils": ^0.38.1-flask.1
     "@metamask/utils": ^7.0.0
@@ -1176,27 +1162,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/permission-controller@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@metamask/permission-controller@npm:4.0.0"
-  dependencies:
-    "@metamask/approval-controller": ^3.0.0
-    "@metamask/base-controller": ^3.0.0
-    "@metamask/controller-utils": ^4.0.0
-    "@metamask/utils": ^5.0.2
-    "@types/deep-freeze-strict": ^1.1.0
-    deep-freeze-strict: ^1.1.1
-    eth-rpc-errors: ^4.0.2
-    immer: ^9.0.6
-    json-rpc-engine: ^6.1.0
-    nanoid: ^3.1.31
-  peerDependencies:
-    "@metamask/approval-controller": ^3.0.0
-  checksum: ac07f6180321f875df1ced0e0c60e872a32b334d5c04c280736ad5bf7c292cf07c97a2e9b49d24ed17145f302e83d24c46d5a4fc423e4a1c939b717c8fa653ec
-  languageName: node
-  linkType: hard
-
-"@metamask/permission-controller@npm:^4.1.0":
+"@metamask/permission-controller@npm:^4.0.0, @metamask/permission-controller@npm:^4.1.0":
   version: 4.1.0
   resolution: "@metamask/permission-controller@npm:4.1.0"
   dependencies:
@@ -1245,6 +1211,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/rpc-methods@npm:0.38.0-preview.6331907, @metamask/rpc-methods@npm:^0.38.0-flask.1":
+  version: 0.38.0-preview.6331907
+  resolution: "@metamask/rpc-methods@npm:0.38.0-preview.6331907::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40metamask%2Frpc-methods%2F0.38.0-preview.6331907%2Ff3fd6b3da99322055ceb60be9ac0720f99b455b6"
+  dependencies:
+    "@metamask/key-tree": ^9.0.0
+    "@metamask/permission-controller": ^4.1.0
+    "@metamask/snaps-ui": 0.37.3-preview.6331907
+    "@metamask/snaps-utils": 0.38.1-preview.6331907
+    "@metamask/types": ^1.1.0
+    "@metamask/utils": ^6.0.1
+    "@noble/hashes": ^1.3.1
+    eth-rpc-errors: ^4.0.3
+    superstruct: ^1.0.3
+  checksum: b25ea2f5ee079eb0545643f1858eb5ebf09ee29cb17bf4b40052eca105c7d7590beb35b133ec901b28e031adcab050eb60ec83c17945456a7b95c72db60b7fd9
+  languageName: node
+  linkType: hard
+
 "@metamask/rpc-methods@npm:^0.37.2-flask.1":
   version: 0.37.2-flask.1
   resolution: "@metamask/rpc-methods@npm:0.37.2-flask.1"
@@ -1259,23 +1242,6 @@ __metadata:
     eth-rpc-errors: ^4.0.3
     superstruct: ^1.0.3
   checksum: f5b955c3a7b7c042c27aa5d9464ea5d9135104c20af3315ea00d8941c5c6379c12c82c0988bc5c21409f4dd8b740bb93b387e2ee115c914b434e28101cd9d877
-  languageName: node
-  linkType: hard
-
-"@metamask/rpc-methods@npm:^0.38.0-flask.1":
-  version: 0.38.0-flask.1
-  resolution: "@metamask/rpc-methods@npm:0.38.0-flask.1"
-  dependencies:
-    "@metamask/key-tree": ^9.0.0
-    "@metamask/permission-controller": ^4.1.0
-    "@metamask/snaps-ui": ^0.37.3-flask.1
-    "@metamask/snaps-utils": ^0.38.1-flask.1
-    "@metamask/types": ^1.1.0
-    "@metamask/utils": ^6.0.1
-    "@noble/hashes": ^1.3.1
-    eth-rpc-errors: ^4.0.3
-    superstruct: ^1.0.3
-  checksum: b9b92c3a1da650b65189cf9dc4a59b17916d0ac21b38dcb68ac4ea048b8b5a98e513e6a72aab114cd1faf8907ed0603908569a9cafec36ff9e6e170ae2630c1e
   languageName: node
   linkType: hard
 
@@ -1363,6 +1329,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/snaps-ui@npm:0.37.3-preview.6331907, @metamask/snaps-ui@npm:^0.37.3-flask.1":
+  version: 0.37.3-preview.6331907
+  resolution: "@metamask/snaps-ui@npm:0.37.3-preview.6331907::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40metamask%2Fsnaps-ui%2F0.37.3-preview.6331907%2F32fa1ae6a311dcfc3eea289008735c76074b2e69"
+  dependencies:
+    "@metamask/utils": ^6.0.1
+    superstruct: ^1.0.3
+  checksum: 8df59ca95f5d614a058a41be27ab4bd1e92270857930ecf4f67c3abc3b4f95cee6f455cb004422372bef603c9732a1554b6872a01ab23ff9a14268c10b35910e
+  languageName: node
+  linkType: hard
+
 "@metamask/snaps-ui@npm:^0.37.2-flask.1":
   version: 0.37.2-flask.1
   resolution: "@metamask/snaps-ui@npm:0.37.2-flask.1"
@@ -1373,13 +1349,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-ui@npm:^0.37.3-flask.1":
-  version: 0.37.3-flask.1
-  resolution: "@metamask/snaps-ui@npm:0.37.3-flask.1"
+"@metamask/snaps-utils@npm:0.38.1-preview.6331907, @metamask/snaps-utils@npm:^0.38.1-flask.1":
+  version: 0.38.1-preview.6331907
+  resolution: "@metamask/snaps-utils@npm:0.38.1-preview.6331907::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40metamask%2Fsnaps-utils%2F0.38.1-preview.6331907%2Fd4d6b7829c0b7962f06ff817b81d285eac3d2e49"
   dependencies:
+    "@babel/core": ^7.20.12
+    "@babel/types": ^7.18.7
+    "@metamask/base-controller": ^3.2.0
+    "@metamask/key-tree": ^9.0.0
+    "@metamask/permission-controller": ^4.1.0
+    "@metamask/snaps-registry": ^1.2.1
+    "@metamask/snaps-ui": 0.37.3-preview.6331907
     "@metamask/utils": ^6.0.1
+    "@noble/hashes": ^1.3.1
+    "@scure/base": ^1.1.1
+    chalk: ^4.1.2
+    cron-parser: ^4.5.0
+    eth-rpc-errors: ^4.0.3
+    fast-deep-equal: ^3.1.3
+    fast-json-stable-stringify: ^2.1.0
+    is-svg: ^4.4.0
+    rfdc: ^1.3.0
+    semver: ^7.5.4
+    ses: ^0.18.7
     superstruct: ^1.0.3
-  checksum: 0b93f6edeca18afc799f16be8b4e4d758800ea0d68298c70492dc85f74ec9f79c2aa32749f6725bb83a4896fdb1ec95a7d19a10a617484e0a7574ddad7969bd3
+    validate-npm-package-name: ^5.0.0
+  checksum: 921fc09724a89cb0d530714c709820c95a1a97d88d6e5a49d920f183c939ff577b94e29c938917c77e7affc20928a650c7c5f59e9e87b41e2342b541dc51ac8a
   languageName: node
   linkType: hard
 
@@ -1443,35 +1438,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-utils@npm:^0.38.1-flask.1":
-  version: 0.38.1-flask.1
-  resolution: "@metamask/snaps-utils@npm:0.38.1-flask.1"
-  dependencies:
-    "@babel/core": ^7.20.12
-    "@babel/types": ^7.18.7
-    "@metamask/base-controller": ^3.2.0
-    "@metamask/key-tree": ^9.0.0
-    "@metamask/permission-controller": ^4.1.0
-    "@metamask/snaps-registry": ^1.2.1
-    "@metamask/snaps-ui": ^0.37.3-flask.1
-    "@metamask/utils": ^6.0.1
-    "@noble/hashes": ^1.3.1
-    "@scure/base": ^1.1.1
-    chalk: ^4.1.2
-    cron-parser: ^4.5.0
-    eth-rpc-errors: ^4.0.3
-    fast-deep-equal: ^3.1.3
-    fast-json-stable-stringify: ^2.1.0
-    is-svg: ^4.4.0
-    rfdc: ^1.3.0
-    semver: ^7.5.4
-    ses: ^0.18.7
-    superstruct: ^1.0.3
-    validate-npm-package-name: ^5.0.0
-  checksum: b968227cce2b570d2f6a205c9a276478edd27ae858679d2a52b56cdb607fb4256d0c773a2a90d3685138d2203b80870be85c924b7ccfc83d737217e9c42cefb8
-  languageName: node
-  linkType: hard
-
 "@metamask/types@npm:^1.1.0":
   version: 1.1.0
   resolution: "@metamask/types@npm:1.1.0"
@@ -1479,7 +1445,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^5.0.0, @metamask/utils@npm:^5.0.2":
+"@metamask/utils@npm:^5.0.0":
   version: 5.0.2
   resolution: "@metamask/utils@npm:5.0.2"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1007,7 +1007,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/base-controller@npm:^3.0.0, @metamask/base-controller@npm:^3.2.0":
+"@metamask/base-controller@npm:^3.2.0":
   version: 3.2.0
   resolution: "@metamask/base-controller@npm:3.2.0"
   dependencies:
@@ -1119,9 +1119,9 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/providers": ^11.0.0
-    "@metamask/rpc-methods": 0.38.0-preview.6331907
-    "@metamask/snaps-controllers": ^0.38.1-flask.1
-    "@metamask/snaps-utils": ^0.38.1-flask.1
+    "@metamask/rpc-methods": ^0.38.1-flask.1
+    "@metamask/snaps-controllers": ^0.38.2-flask.1
+    "@metamask/snaps-utils": ^0.38.2-flask.1
     "@metamask/utils": ^7.0.0
     "@types/jest": ^28.1.6
     "@types/node": ^16
@@ -1162,7 +1162,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/permission-controller@npm:^4.0.0, @metamask/permission-controller@npm:^4.1.0":
+"@metamask/permission-controller@npm:^4.1.0":
   version: 4.1.0
   resolution: "@metamask/permission-controller@npm:4.1.0"
   dependencies:
@@ -1192,7 +1192,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/providers@npm:^11.0.0":
+"@metamask/providers@npm:^11.0.0, @metamask/providers@npm:^11.1.1":
   version: 11.1.1
   resolution: "@metamask/providers@npm:11.1.1"
   dependencies:
@@ -1211,37 +1211,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/rpc-methods@npm:0.38.0-preview.6331907, @metamask/rpc-methods@npm:^0.38.0-flask.1":
-  version: 0.38.0-preview.6331907
-  resolution: "@metamask/rpc-methods@npm:0.38.0-preview.6331907::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40metamask%2Frpc-methods%2F0.38.0-preview.6331907%2Ff3fd6b3da99322055ceb60be9ac0720f99b455b6"
+"@metamask/rpc-methods@npm:^0.38.1-flask.1":
+  version: 0.38.1-flask.1
+  resolution: "@metamask/rpc-methods@npm:0.38.1-flask.1"
   dependencies:
     "@metamask/key-tree": ^9.0.0
     "@metamask/permission-controller": ^4.1.0
-    "@metamask/snaps-ui": 0.37.3-preview.6331907
-    "@metamask/snaps-utils": 0.38.1-preview.6331907
+    "@metamask/snaps-ui": ^0.37.4-flask.1
+    "@metamask/snaps-utils": ^0.38.2-flask.1
     "@metamask/types": ^1.1.0
     "@metamask/utils": ^6.0.1
     "@noble/hashes": ^1.3.1
     eth-rpc-errors: ^4.0.3
     superstruct: ^1.0.3
-  checksum: b25ea2f5ee079eb0545643f1858eb5ebf09ee29cb17bf4b40052eca105c7d7590beb35b133ec901b28e031adcab050eb60ec83c17945456a7b95c72db60b7fd9
-  languageName: node
-  linkType: hard
-
-"@metamask/rpc-methods@npm:^0.37.2-flask.1":
-  version: 0.37.2-flask.1
-  resolution: "@metamask/rpc-methods@npm:0.37.2-flask.1"
-  dependencies:
-    "@metamask/key-tree": ^9.0.0
-    "@metamask/permission-controller": ^4.0.0
-    "@metamask/snaps-ui": ^0.37.2-flask.1
-    "@metamask/snaps-utils": ^0.37.2-flask.1
-    "@metamask/types": ^1.1.0
-    "@metamask/utils": ^6.0.1
-    "@noble/hashes": ^1.3.1
-    eth-rpc-errors: ^4.0.3
-    superstruct: ^1.0.3
-  checksum: f5b955c3a7b7c042c27aa5d9464ea5d9135104c20af3315ea00d8941c5c6379c12c82c0988bc5c21409f4dd8b740bb93b387e2ee115c914b434e28101cd9d877
+  checksum: 49700a41a1340d36d484086a4f6ca0a3fea27f5f8119c9a9af9c2cd0aeecf7f603f6c89a2f122232c66a238e281023df82d4ad38c799da5a137ccfcf0bca6857
   languageName: node
   linkType: hard
 
@@ -1269,19 +1252,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-controllers@npm:^0.38.1-flask.1":
-  version: 0.38.1-flask.1
-  resolution: "@metamask/snaps-controllers@npm:0.38.1-flask.1"
+"@metamask/snaps-controllers@npm:^0.38.2-flask.1":
+  version: 0.38.2-flask.1
+  resolution: "@metamask/snaps-controllers@npm:0.38.2-flask.1"
   dependencies:
     "@metamask/approval-controller": ^3.5.0
     "@metamask/base-controller": ^3.2.0
     "@metamask/object-multiplex": ^1.2.0
     "@metamask/permission-controller": ^4.1.0
     "@metamask/post-message-stream": ^6.1.2
-    "@metamask/rpc-methods": ^0.38.0-flask.1
-    "@metamask/snaps-execution-environments": ^0.38.1-flask.1
+    "@metamask/rpc-methods": ^0.38.1-flask.1
+    "@metamask/snaps-execution-environments": ^0.38.2-flask.1
     "@metamask/snaps-registry": ^1.2.1
-    "@metamask/snaps-utils": ^0.38.1-flask.1
+    "@metamask/snaps-utils": ^0.38.2-flask.1
     "@metamask/utils": ^6.0.1
     "@xstate/fsm": ^2.0.0
     concat-stream: ^2.0.0
@@ -1294,27 +1277,26 @@ __metadata:
     pump: ^3.0.0
     readable-web-to-node-stream: ^3.0.2
     tar-stream: ^2.2.0
-  checksum: 40efc1d2d2804140b58c6fabe1bd957d807e6669f28cff3680835d66f3db305defd09f5be21d4134569c51690e31cb1a940294dd65b26c35b088bbf9747eb48a
+  checksum: 738044e70b079fd62195219aa68260b4afae4855826b8d7b94f53edad69d8befaf77c67c2a9dbf2363457223b0560652578eeea438150d37a56a4adcd89e6e43
   languageName: node
   linkType: hard
 
-"@metamask/snaps-execution-environments@npm:^0.38.1-flask.1":
-  version: 0.38.1-flask.1
-  resolution: "@metamask/snaps-execution-environments@npm:0.38.1-flask.1"
+"@metamask/snaps-execution-environments@npm:^0.38.2-flask.1":
+  version: 0.38.2-flask.1
+  resolution: "@metamask/snaps-execution-environments@npm:0.38.2-flask.1"
   dependencies:
     "@metamask/object-multiplex": ^1.2.0
     "@metamask/post-message-stream": ^6.1.2
-    "@metamask/providers": ^11.0.0
-    "@metamask/rpc-methods": ^0.37.2-flask.1
-    "@metamask/snaps-utils": ^0.38.0-flask.1
+    "@metamask/providers": ^11.1.1
+    "@metamask/rpc-methods": ^0.38.1-flask.1
+    "@metamask/snaps-utils": ^0.38.2-flask.1
     "@metamask/utils": ^6.0.1
     eth-rpc-errors: ^4.0.3
     json-rpc-engine: ^6.1.0
     nanoid: ^3.1.31
     pump: ^3.0.0
-    stream-browserify: ^3.0.0
     superstruct: ^1.0.3
-  checksum: 087e8ecc2b8826b79316f21cd9b1cb359d61586d35590d3c8fc8b11e63a9f23d225ae2019d8055132591907b93994a1e1616d5ebf030db7cd4657b3bbd6e3ea6
+  checksum: 68c1adcb8fe227c989c02ea5f7820f0d58b0e9442b21d0043e2f06a7ea3a6607a5e0bdde82aceecc12e265b27bd1e5a719fb4ec901f19adea3a37d5412ca8415
   languageName: node
   linkType: hard
 
@@ -1329,29 +1311,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-ui@npm:0.37.3-preview.6331907, @metamask/snaps-ui@npm:^0.37.3-flask.1":
-  version: 0.37.3-preview.6331907
-  resolution: "@metamask/snaps-ui@npm:0.37.3-preview.6331907::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40metamask%2Fsnaps-ui%2F0.37.3-preview.6331907%2F32fa1ae6a311dcfc3eea289008735c76074b2e69"
+"@metamask/snaps-ui@npm:^0.37.4-flask.1":
+  version: 0.37.4-flask.1
+  resolution: "@metamask/snaps-ui@npm:0.37.4-flask.1"
   dependencies:
     "@metamask/utils": ^6.0.1
     superstruct: ^1.0.3
-  checksum: 8df59ca95f5d614a058a41be27ab4bd1e92270857930ecf4f67c3abc3b4f95cee6f455cb004422372bef603c9732a1554b6872a01ab23ff9a14268c10b35910e
+  checksum: d4e0a3c5f82a6edbf7bc82280fab364b93787e7d9995854208dd4200e188f37691216928967a5b75e6be5ebfeb360e638af39ac0043f1bdddb0c2ff7a5cdbce5
   languageName: node
   linkType: hard
 
-"@metamask/snaps-ui@npm:^0.37.2-flask.1":
-  version: 0.37.2-flask.1
-  resolution: "@metamask/snaps-ui@npm:0.37.2-flask.1"
-  dependencies:
-    "@metamask/utils": ^6.0.1
-    superstruct: ^1.0.3
-  checksum: a52a887411d689a7a0b017b3741c76819567416c7943ca3c71f5b5f8b623605689f370f70caa8a22531d711d10738c913b0d561fcda09a92c38e288d115e6bac
-  languageName: node
-  linkType: hard
-
-"@metamask/snaps-utils@npm:0.38.1-preview.6331907, @metamask/snaps-utils@npm:^0.38.1-flask.1":
-  version: 0.38.1-preview.6331907
-  resolution: "@metamask/snaps-utils@npm:0.38.1-preview.6331907::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40metamask%2Fsnaps-utils%2F0.38.1-preview.6331907%2Fd4d6b7829c0b7962f06ff817b81d285eac3d2e49"
+"@metamask/snaps-utils@npm:^0.38.2-flask.1":
+  version: 0.38.2-flask.1
+  resolution: "@metamask/snaps-utils@npm:0.38.2-flask.1"
   dependencies:
     "@babel/core": ^7.20.12
     "@babel/types": ^7.18.7
@@ -1359,7 +1331,7 @@ __metadata:
     "@metamask/key-tree": ^9.0.0
     "@metamask/permission-controller": ^4.1.0
     "@metamask/snaps-registry": ^1.2.1
-    "@metamask/snaps-ui": 0.37.3-preview.6331907
+    "@metamask/snaps-ui": ^0.37.4-flask.1
     "@metamask/utils": ^6.0.1
     "@noble/hashes": ^1.3.1
     "@scure/base": ^1.1.1
@@ -1374,67 +1346,7 @@ __metadata:
     ses: ^0.18.7
     superstruct: ^1.0.3
     validate-npm-package-name: ^5.0.0
-  checksum: 921fc09724a89cb0d530714c709820c95a1a97d88d6e5a49d920f183c939ff577b94e29c938917c77e7affc20928a650c7c5f59e9e87b41e2342b541dc51ac8a
-  languageName: node
-  linkType: hard
-
-"@metamask/snaps-utils@npm:^0.37.2-flask.1":
-  version: 0.37.2-flask.1
-  resolution: "@metamask/snaps-utils@npm:0.37.2-flask.1"
-  dependencies:
-    "@babel/core": ^7.20.12
-    "@babel/types": ^7.18.7
-    "@metamask/base-controller": ^3.0.0
-    "@metamask/key-tree": ^9.0.0
-    "@metamask/permission-controller": ^4.0.0
-    "@metamask/providers": ^11.0.0
-    "@metamask/snaps-registry": ^1.2.1
-    "@metamask/snaps-ui": ^0.37.2-flask.1
-    "@metamask/utils": ^6.0.1
-    "@noble/hashes": ^1.3.1
-    "@scure/base": ^1.1.1
-    chalk: ^4.1.2
-    cron-parser: ^4.5.0
-    eth-rpc-errors: ^4.0.3
-    fast-deep-equal: ^3.1.3
-    fast-json-stable-stringify: ^2.1.0
-    is-svg: ^4.4.0
-    rfdc: ^1.3.0
-    semver: ^7.3.7
-    ses: ^0.18.1
-    superstruct: ^1.0.3
-    validate-npm-package-name: ^5.0.0
-  checksum: eeb31013a8af39b5488fdb8a6a72e11c54274e423e0f2560fd5cf4ea0278e278aff60be070c1e5b847d84220f15338e01c4725ce7ebb5f3fc614553ae4235f44
-  languageName: node
-  linkType: hard
-
-"@metamask/snaps-utils@npm:^0.38.0-flask.1":
-  version: 0.38.0-flask.1
-  resolution: "@metamask/snaps-utils@npm:0.38.0-flask.1"
-  dependencies:
-    "@babel/core": ^7.20.12
-    "@babel/types": ^7.18.7
-    "@metamask/base-controller": ^3.0.0
-    "@metamask/key-tree": ^9.0.0
-    "@metamask/permission-controller": ^4.0.0
-    "@metamask/providers": ^11.0.0
-    "@metamask/snaps-registry": ^1.2.1
-    "@metamask/snaps-ui": ^0.37.3-flask.1
-    "@metamask/utils": ^6.0.1
-    "@noble/hashes": ^1.3.1
-    "@scure/base": ^1.1.1
-    chalk: ^4.1.2
-    cron-parser: ^4.5.0
-    eth-rpc-errors: ^4.0.3
-    fast-deep-equal: ^3.1.3
-    fast-json-stable-stringify: ^2.1.0
-    is-svg: ^4.4.0
-    rfdc: ^1.3.0
-    semver: ^7.5.4
-    ses: ^0.18.1
-    superstruct: ^1.0.3
-    validate-npm-package-name: ^5.0.0
-  checksum: 9b79feabcf3a99f0faa53c87711e0de155807d49dd3a9117933b9636d529fa3f3449bd563535f056fc7cbb3eaffcd9e9703b02985bdb6cfdc090d096d76dad8e
+  checksum: cb95a67a1267299aacb5b85b25a35dbfd14f68060198974cc1a26b9a2e7eff5acd13700b9100e3546dfc7e78ed937b06aecb5c4884c32ff77b2d28c77e7f97b6
   languageName: node
   linkType: hard
 
@@ -4670,7 +4582,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2, inherits@npm:^2.0.1, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.3, inherits@npm:~2.0.4":
+"inherits@npm:2, inherits@npm:^2.0.1, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.3":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 4a48a733847879d6cf6691860a6b1e3f0f4754176e4d71494c41f3475553768b10f84b5ce1d40fbd0e34e6bfbb864ee35858ad4dd2cf31e02fc4a154b724d7f1
@@ -6749,7 +6661,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^3.0.2, readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0, readable-stream@npm:^3.5.0, readable-stream@npm:^3.6.0":
+"readable-stream@npm:^3.0.2, readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0, readable-stream@npm:^3.6.0":
   version: 3.6.2
   resolution: "readable-stream@npm:3.6.2"
   dependencies:
@@ -7038,7 +6950,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ses@npm:^0.18.1, ses@npm:^0.18.7":
+"ses@npm:^0.18.7":
   version: 0.18.7
   resolution: "ses@npm:0.18.7"
   dependencies:
@@ -7268,16 +7180,6 @@ __metadata:
   dependencies:
     escape-string-regexp: ^2.0.0
   checksum: 052bf4d25bbf5f78e06c1d5e67de2e088b06871fa04107ca8d3f0e9d9263326e2942c8bedee3545795fc77d787d443a538345eef74db2f8e35db3558c6f91ff7
-  languageName: node
-  linkType: hard
-
-"stream-browserify@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "stream-browserify@npm:3.0.0"
-  dependencies:
-    inherits: ~2.0.4
-    readable-stream: ^3.5.0
-  checksum: 4c47ef64d6f03815a9ca3874e2319805e8e8a85f3550776c47ce523b6f4c6cd57f40e46ec6a9ab8ad260fde61863c2718f250d3bedb3fe9052444eb9abfd9921
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The events added by this PR are intended to replace the existing `snap_manageAccount` methods. Events are more semantically correct, as the keyring's role is to notify the Keyring Controller/Bridge specifically about events related to accounts and requests.

Additionally, this PR introduces a helper function that enables snaps to emit these events.