### PR TITLE
fix: update snap object keys to be mandatory and move name to metadata

### DIFF
--- a/src/internal/types.test.ts
+++ b/src/internal/types.test.ts
@@ -90,4 +90,57 @@ describe('InternalAccount', () => {
       'At path: metadata.extra -- Expected a value of type `never`',
     );
   });
+
+  it('should contain snap name, id and enabled if the snap metadata exists', () => {
+    const account = {
+      id: '606a7759-b0fb-48e4-9874-bab62ff8e7eb',
+      address: '0x000',
+      options: {},
+      methods: [],
+      type: 'eip155:eoa',
+      metadata: {
+        keyring: {
+          type: 'Test Keyring',
+        },
+        name: 'Account 1',
+        snap: {
+          id: 'test-snap',
+          enabled: true,
+          name: 'Test Snap',
+        },
+      },
+    };
+
+    expect(() => assert(account, InternalAccountStruct)).not.toThrow();
+  });
+
+  it.each([['name', 'enabled', 'id']])(
+    'should throw if snap.%i is not set',
+    (key: string) => {
+      const account = {
+        id: '606a7759-b0fb-48e4-9874-bab62ff8e7eb',
+        address: '0x000',
+        options: {},
+        methods: [],
+        type: 'eip155:eoa',
+        metadata: {
+          keyring: {
+            type: 'Test Keyring',
+          },
+          name: 'Account 1',
+          snap: {
+            id: 'test-snap',
+            enabled: true,
+            name: 'Test Snap',
+          },
+        },
+      };
+
+      delete account.metadata.snap[key as keyof typeof account.metadata.snap];
+
+      const regex = new RegExp(`At path: metadata.snap.${key}`, 'u');
+
+      expect(() => assert(account, InternalAccountStruct)).toThrow(regex);
+    },
+  );
 });

--- a/src/internal/types.test.ts
+++ b/src/internal/types.test.ts
@@ -14,6 +14,7 @@ describe('InternalAccount', () => {
         keyring: {
           type: 'Test Keyring',
         },
+        name: 'Account 1',
       },
     };
 
@@ -29,6 +30,7 @@ describe('InternalAccount', () => {
       type: 'eip155:eoa',
       metadata: {
         keyring: {},
+        name: 'Account 1',
       },
     };
 
@@ -44,7 +46,9 @@ describe('InternalAccount', () => {
       options: {},
       methods: [],
       type: 'eip155:eoa',
-      metadata: {},
+      metadata: {
+        name: 'Account 1',
+      },
     };
 
     expect(() => assert(account, InternalAccountStruct)).toThrow(
@@ -77,6 +81,7 @@ describe('InternalAccount', () => {
         keyring: {
           type: 'Test Keyring',
         },
+        name: 'Account 1',
         extra: 'field',
       },
     };

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -9,6 +9,7 @@ export const InternalAccountStruct = object({
       object({
         id: string(),
         enabled: boolean(),
+        name: string(),
       }),
     ),
     name: string(),

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -7,11 +7,11 @@ export const InternalAccountStruct = object({
   metadata: object({
     snap: optional(
       object({
-        id: optional(string()),
-        name: optional(string()),
-        enabled: optional(boolean()),
+        id: string(),
+        enabled: boolean(),
       }),
     ),
+    name: string(),
     keyring: object({
       type: string(),
     }),


### PR DESCRIPTION
Changes to the Internal Account: 

- Makes keys in the snap object mandatory 
- Moves the name key from the snap object to metadata