### PR TITLE
feat: add redirection message to snap async response

### DIFF
--- a/src/KeyringClient.test.ts
+++ b/src/KeyringClient.test.ts
@@ -224,7 +224,10 @@ describe('KeyringClient', () => {
       };
       const expectedResponse: KeyringResponse = {
         pending: true,
-        redirect: null,
+        redirect: {
+          message: 'Please continue to the dapp',
+          url: 'https://example.com',
+        },
       };
 
       mockSender.send.mockResolvedValue(expectedResponse);

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,15 +1,7 @@
 import type { Json } from '@metamask/utils';
 import { JsonStruct } from '@metamask/utils';
 import type { Infer } from 'superstruct';
-import {
-  array,
-  enums,
-  literal,
-  record,
-  string,
-  union,
-  nullable,
-} from 'superstruct';
+import { array, enums, literal, record, string, union } from 'superstruct';
 
 import { exactOptional, object } from './superstruct';
 import { UuidStruct } from './utils';
@@ -140,7 +132,12 @@ export const KeyringResponseStruct = union([
      * with a link to the redirect URL. The user can choose to follow the link
      * or cancel the request.
      */
-    redirect: nullable(string()),
+    redirect: exactOptional(
+      object({
+        message: exactOptional(string()),
+        url: exactOptional(string()),
+      }),
+    ),
   }),
   object({
     /**


### PR DESCRIPTION
This PR adds an optional `message` field to the snap's response in the async flow.