### PR TITLE
chore(docs): fix some typos and consistency problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Usage examples to [`README.md`](./README.md).
 - Keyring API definition.
-- JSON-RPC snap keyring client. It is intended to be used by a snap's companion dApp to send requests to the snap.
+- JSON-RPC snap keyring client. It is intended to be used by a snap's companion dapp to send requests to the snap.
 - SnapController keyring client. It is intended to be used by MetaMask to talk to the snap.
 - Helper functions to create keyring handler in the snap.
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Features:
   Keyring API. Snaps can implement this interface to seamlessly interact with
   MetaMask and leverage its functionality.
 
-- **DApp Client**: The module includes a client that enables dApps to
-  communicate with the Keyring snap. This client allows dApps to send requests
+- **Dapp Client**: The module includes a client that enables dapps to
+  communicate with the Keyring snap. This client allows dapps to send requests
   to the snap, such as retrieving account information or submitting requests.
 
 - **MetaMask Client**: The module provides a client specifically designed for
@@ -23,7 +23,7 @@ Features:
 - **Request Handler Helper Functions**: The module offers a set of helper
   functions to simplify the implementation of the request handler in the
   Keyring snap. These functions assist in processing incoming requests,
-  validating data, and handling various request types from dApps and MetaMask.
+  validating data, and handling various request types from dapps and MetaMask.
 
 ## Installation
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,7 @@ Let's introduce some terminology used across the Keyring API:
 - **Blockchain account**: An object in a single blockchain, representing an
   account, with its balance, nonce, etc.
 
-- **Request**: A request sent by a dApp to MetaMask.
+- **Request**: A request sent by a dapp to MetaMask.
 
 - **Keyring account**: Is an account model that represents one or more
   blockchain accounts.
@@ -16,7 +16,7 @@ Let's introduce some terminology used across the Keyring API:
 
 - **Keyring request**: A request from MetaMask to a keyring snap, to perform an
   action on or using a keyring account. It wraps the original request sent by
-  the dApp and adds some metadata to it.
+  the dapp and adds some metadata to it.
 
 ## Components diagram
 
@@ -25,32 +25,32 @@ with an account managed by a keyring snap:
 
 ```mermaid
 graph TD
-  User -->|Starts a request| DApp
-  DApp -->|Submits a request| MetaMask
+  User -->|Starts a request| Dapp
+  Dapp -->|Submits a request| MetaMask
   MetaMask -->|Submits requests<br/>and manages accounts| Snap
-  Site[Snap DApp] -->|Manages requests<br/>and accounts| Snap
+  Site[Snap Dapp] -->|Manages requests<br/>and accounts| Snap
   User -.->|Uses for snap-specific logic| Site
 ```
 
-- **User**: The web3 user interacting with the snap, the dApp, and MetaMask.
+- **User**: The web3 user interacting with the snap, the dapp, and MetaMask.
 
-- **DApp**: The web3 application that is requesting an action to be performed
+- **Dapp**: The web3 application that is requesting an action to be performed
   on an account.
 
-- **MetaMask**: The web3 provider that dApps connect to. It routes requests to
+- **MetaMask**: The web3 provider that dapps connect to. It routes requests to
   the keyring snaps and lets the user perform some level of account management.
 
 - **Snap**: A snap that implements the Keyring API to manage the user's
   accounts, and to handle requests that use these accounts.
 
-- **Snap DApp**: The snap's UI component that allows the user to interact with
+- **Snap Dapp**: The snap's UI component that allows the user to interact with
   the snap to perform custom operations on accounts and requests.
 
 ## Account creation
 
 The account creation flow is the initial process that a user will encounter
-when using a keyring snap. It can be triggered by the "Add snap account" button
-in the accounts list or by the Snap DApp.
+when using a keyring snap. It can be triggered by the "Add Snap account" button
+in the accounts list or by the Snap dapp.
 
 ```mermaid
 sequenceDiagram
@@ -59,18 +59,16 @@ autonumber
 actor User
 participant MetaMask
 participant Snap
-participant Site as Snap DApp
+participant Site as Snap Dapp
 
-alt Optional
-  User ->>+ MetaMask: Add new snap account
+alt If the snap is not installed yet
+  User ->>+ MetaMask: Add new Snap account
   MetaMask ->> MetaMask: Display suggested snaps
   User ->> MetaMask: Select snap
   MetaMask ->> Site: Open in a new tab
   deactivate MetaMask
-end
 
-alt If the snap is not installed yet
-  Site ->>+ MetaMask: Install snap
+  Site ->>+ MetaMask: Install snap?
   MetaMask ->> MetaMask: Display permissions dialog
   User ->> MetaMask: Approve permissions
   MetaMask -->>- Site: OK
@@ -105,10 +103,10 @@ The Keyring API supports two different flows for signing transactions:
   autonumber
 
   actor User
-  participant DApp
+  participant Dapp
   participant MetaMask
   participant Snap
-  participant Site as Snap DApp
+  participant Site as Snap Dapp
 
   User ->>+ DApp: Create new sign request
   DApp ->>+ MetaMask: ethereum.request(request)
@@ -137,12 +135,12 @@ The Keyring API supports two different flows for signing transactions:
   Snap ->> Snap: Custom logic to handle request
   Snap ->>+ MetaMask: snap_manageAccounts("event:requestApproved", { id, result })
 
-  MetaMask -->> DApp: result
+  MetaMask -->> Dapp: result
   MetaMask -->>- Snap: OK
   Snap -->>- Site: OK
   deactivate Site
 
-  DApp -->>- User: Done
+  Dapp -->>- User: Done
   ```
 
 - **Synchronous**: MetaMask sends a keyring request to the keyring snap, and
@@ -154,7 +152,7 @@ The Keyring API supports two different flows for signing transactions:
   autonumber
 
   actor User
-  participant DApp
+  participant Dapp
   participant MetaMask
   participant Snap
 
@@ -167,7 +165,7 @@ The Keyring API supports two different flows for signing transactions:
   Snap ->> Snap: Custom logic to handle request
   Snap -->>- MetaMask: { pendind: false, result }
 
-  MetaMask -->>- DApp: result
+  MetaMask -->>- Dapp: result
 
-  DApp -->>- User: Done
+  Dapp -->>- User: Done
   ```

--- a/docs/evm_methods.md
+++ b/docs/evm_methods.md
@@ -1,7 +1,7 @@
 # EVM Methods
 
 Here we document the methods that a keyring snap may implement to support
-requests originated from dApps.
+requests originated from dapps.
 
 > [!NOTE]
 > The methods described here may have different returns values than the ones


### PR DESCRIPTION
Fix some typos and try to be consistent with other [docs](https://support.metamask.io/hc/en-us/articles/4405506066331-User-Guide-Dapps) (i.e. use **Dapp** and **dapp**).