### PR TITLE
refactor!: change the events' prefix to `notify:`

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -3,11 +3,11 @@
  */
 export enum KeyringEvent {
   // Account events
-  AccountCreated = 'event:accountCreated',
-  AccountUpdated = 'event:accountUpdated',
-  AccountDeleted = 'event:accountDeleted',
+  AccountCreated = 'notify:accountCreated',
+  AccountUpdated = 'notify:accountUpdated',
+  AccountDeleted = 'notify:accountDeleted',
 
   // Request events
-  RequestApproved = 'event:requestApproved',
-  RequestRejected = 'event:requestRejected',
+  RequestApproved = 'notify:requestApproved',
+  RequestRejected = 'notify:requestRejected',
 }


### PR DESCRIPTION
This is more in line with the fact that events are sent to the extension as an RPC call.

```ts
await snap.request({
  method: 'snap_manageAccounts',
  params: {
    method: 'notify:accountCreated',
    params: { account },
  },
});
```

BREAKING: This is a braking change, but users shouldn't be concerned since it only changes the enum values.