### PR TITLE
fix: allow the request ID to be a string, number or null

### DIFF
--- a/src/internal/api.ts
+++ b/src/internal/api.ts
@@ -16,6 +16,7 @@ import {
   KeyringRequestStruct,
   KeyringResponseStruct,
 } from '../api';
+import { UuidStruct } from '../utils';
 
 const CommonHeader = {
   jsonrpc: literal('2.0'),

--- a/src/internal/api.ts
+++ b/src/internal/api.ts
@@ -1,6 +1,14 @@
 import { JsonStruct } from '@metamask/utils';
 import type { Infer } from 'superstruct';
-import { array, literal, object, record, string } from 'superstruct';
+import {
+  array,
+  literal,
+  number,
+  object,
+  record,
+  string,
+  union,
+} from 'superstruct';
 
 import {
   KeyringAccountDataStruct,
@@ -8,11 +16,10 @@ import {
   KeyringRequestStruct,
   KeyringResponseStruct,
 } from '../api';
-import { UuidStruct } from '../utils';
 
 const CommonHeader = {
   jsonrpc: literal('2.0'),
-  id: UuidStruct,
+  id: union([string(), number(), literal(null)]),
 };
 
 // ----------------------------------------------------------------------------

--- a/src/rpc-handler.test.ts
+++ b/src/rpc-handler.test.ts
@@ -345,15 +345,49 @@ describe('keyringRpcDispatcher', () => {
     );
   });
 
-  it('should fail to list requests with a non-UUIDv4 request ID', async () => {
+  it('calls the keyring with a non-UUIDv4 string request ID', async () => {
     const request: JsonRpcRequest = {
       jsonrpc: '2.0',
-      id: 'invalid-id-string',
+      id: 'request-id',
       method: 'keyring_listRequests',
     };
 
+    keyring.listRequests.mockResolvedValue([]);
+    expect(await handleKeyringRequest(keyring, request)).toStrictEqual([]);
+  });
+
+  it('calls the keyring with a number request ID', async () => {
+    const request: JsonRpcRequest = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'keyring_listRequests',
+    };
+
+    keyring.listRequests.mockResolvedValue([]);
+    expect(await handleKeyringRequest(keyring, request)).toStrictEqual([]);
+  });
+
+  it('calls the keyring with a null request ID', async () => {
+    const request: JsonRpcRequest = {
+      jsonrpc: '2.0',
+      id: null,
+      method: 'keyring_listRequests',
+    };
+
+    keyring.listRequests.mockResolvedValue([]);
+    expect(await handleKeyringRequest(keyring, request)).toStrictEqual([]);
+  });
+
+  it('fails to call the keyring with a boolean request ID', async () => {
+    const request: JsonRpcRequest = {
+      jsonrpc: '2.0',
+      id: true as any,
+      method: 'keyring_listRequests',
+    };
+
+    keyring.listRequests.mockResolvedValue([]);
     await expect(handleKeyringRequest(keyring, request)).rejects.toThrow(
-      'At path: id -- Expected a string matching',
+      'At path: id -- Expected the value to satisfy a union of `string | number | literal`, but received: true',
     );
   });
 


### PR DESCRIPTION
## **Description**

The current API forces the ID of the JSON-RPC requests to be a UUIDv4, which is not compliant with the official JSON-RPC specs. Note, however, that this constraint doesn't have an impact on devs who use the Keyring clients, such as `KeyringSnapRpcClient` and `KeyringSnapControllerClient`.

This PR removes this limitation and allows the request ID to be any string, number or null.

## **Related issues**

Fixes #154