### PR TITLE
refactor: move internal RPC methods to `rpc.ts`

### DIFF
--- a/src/KeyringClient.ts
+++ b/src/KeyringClient.ts
@@ -23,8 +23,8 @@ import {
   SubmitRequestResponseStruct,
   UpdateAccountResponseStruct,
 } from './internal/api';
+import { KeyringRpcMethod } from './internal/rpc';
 import type { JsonRpcRequest } from './JsonRpcRequest';
-import { KeyringRpcMethod } from './rpc-handler';
 import { strictMask } from './utils';
 
 export type Sender = {

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -1,3 +1,4 @@
 export * from './api';
 export * from './events';
+export * from './rpc';
 export * from './types';

--- a/src/internal/rpc.ts
+++ b/src/internal/rpc.ts
@@ -1,0 +1,27 @@
+/**
+ * Keyring RPC methods used by the API.
+ */
+export enum KeyringRpcMethod {
+  ListAccounts = 'keyring_listAccounts',
+  GetAccount = 'keyring_getAccount',
+  CreateAccount = 'keyring_createAccount',
+  FilterAccountChains = 'keyring_filterAccountChains',
+  UpdateAccount = 'keyring_updateAccount',
+  DeleteAccount = 'keyring_deleteAccount',
+  ExportAccount = 'keyring_exportAccount',
+  ListRequests = 'keyring_listRequests',
+  GetRequest = 'keyring_getRequest',
+  SubmitRequest = 'keyring_submitRequest',
+  ApproveRequest = 'keyring_approveRequest',
+  RejectRequest = 'keyring_rejectRequest',
+}
+
+/**
+ * Check if a method is a keyring RPC method.
+ *
+ * @param method - Method to check.
+ * @returns Whether the method is a keyring RPC method.
+ */
+export function isKeyringRpcMethod(method: string): boolean {
+  return Object.values(KeyringRpcMethod).includes(method as KeyringRpcMethod);
+}

--- a/src/rpc-handler.test.ts
+++ b/src/rpc-handler.test.ts
@@ -1,11 +1,7 @@
 import type { Keyring } from './api';
+import { KeyringRpcMethod, isKeyringRpcMethod } from './internal/rpc';
 import type { JsonRpcRequest } from './JsonRpcRequest';
-import {
-  KeyringRpcMethod,
-  MethodNotSupportedError,
-  handleKeyringRequest,
-  isKeyringRpcMethod,
-} from './rpc-handler';
+import { MethodNotSupportedError, handleKeyringRequest } from './rpc-handler';
 
 describe('keyringRpcDispatcher', () => {
   const keyring = {

--- a/src/rpc-handler.ts
+++ b/src/rpc-handler.ts
@@ -16,6 +16,7 @@ import {
   ListAccountsRequestStruct,
   ListRequestsRequestStruct,
 } from './internal/api';
+import { KeyringRpcMethod } from './internal/rpc';
 import type { JsonRpcRequest } from './JsonRpcRequest';
 import { JsonRpcRequestStruct } from './JsonRpcRequest';
 
@@ -26,21 +27,6 @@ export class MethodNotSupportedError extends Error {
   constructor(method: string) {
     super(`Method not supported: ${method}`);
   }
-}
-
-export enum KeyringRpcMethod {
-  ListAccounts = 'keyring_listAccounts',
-  GetAccount = 'keyring_getAccount',
-  CreateAccount = 'keyring_createAccount',
-  FilterAccountChains = 'keyring_filterAccountChains',
-  UpdateAccount = 'keyring_updateAccount',
-  DeleteAccount = 'keyring_deleteAccount',
-  ExportAccount = 'keyring_exportAccount',
-  ListRequests = 'keyring_listRequests',
-  GetRequest = 'keyring_getRequest',
-  SubmitRequest = 'keyring_submitRequest',
-  ApproveRequest = 'keyring_approveRequest',
-  RejectRequest = 'keyring_rejectRequest',
 }
 
 /**
@@ -141,14 +127,4 @@ export async function handleKeyringRequest(
       throw new MethodNotSupportedError(request.method);
     }
   }
-}
-
-/**
- * Check if a method is a keyring RPC method.
- *
- * @param method - Method to check.
- * @returns Whether the method is a keyring RPC method.
- */
-export function isKeyringRpcMethod(method: string): boolean {
-  return Object.values(KeyringRpcMethod).includes(method as KeyringRpcMethod);
 }


### PR DESCRIPTION
## **Description**

For clarity, this PR moves the internal RPC methods to `internal/rpc.ts`.