### PR TITLE
test: enable lcov report exporter

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -36,7 +36,7 @@ module.exports = {
   coverageProvider: 'babel',
 
   // A list of reporter names that Jest uses when writing coverage reports
-  coverageReporters: ['html', 'json-summary', 'text'],
+  coverageReporters: ['html', 'json-summary', 'text', 'lcov'],
 
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {


### PR DESCRIPTION
This PR enables the lcov report exporter available in Jest, it makes easier to use some code coverage tools.