### PR TITLE
Remove @metamask/snaps-ui from dependency tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
   },
   "dependencies": {
     "@metamask/providers": "^13.0.0",
-    "@metamask/snaps-controllers": "^3.1.0",
-    "@metamask/snaps-rpc-methods": "^3.1.0",
-    "@metamask/snaps-utils": "^3.0.0",
+    "@metamask/snaps-controllers": "^3.4.0",
+    "@metamask/snaps-sdk": "^1.1.0",
+    "@metamask/snaps-utils": "^4.0.1",
     "@metamask/utils": "^8.1.0",
     "@types/uuid": "^9.0.1",
     "superstruct": "^1.0.3",

--- a/src/KeyringSnapControllerClient.test.ts
+++ b/src/KeyringSnapControllerClient.test.ts
@@ -1,10 +1,11 @@
 import type { SnapController } from '@metamask/snaps-controllers';
+import type { SnapId } from '@metamask/snaps-sdk';
 
 import type { KeyringAccount } from './api';
 import { KeyringSnapControllerClient } from './KeyringSnapControllerClient';
 
 describe('KeyringSnapControllerClient', () => {
-  const snapId = 'local:localhost:3000';
+  const snapId = 'local:localhost:3000' as SnapId;
 
   const accountsList: KeyringAccount[] = [
     {

--- a/src/KeyringSnapControllerClient.ts
+++ b/src/KeyringSnapControllerClient.ts
@@ -1,5 +1,6 @@
 import type { SnapController } from '@metamask/snaps-controllers';
-import type { HandlerType, ValidatedSnapId } from '@metamask/snaps-utils';
+import type { SnapId } from '@metamask/snaps-sdk';
+import type { HandlerType } from '@metamask/snaps-utils';
 import type { Json } from '@metamask/utils';
 
 import type { JsonRpcRequest } from './JsonRpcRequest';
@@ -10,7 +11,7 @@ import { KeyringClient, type Sender } from './KeyringClient';
  * to a snap through a `SnapController`.
  */
 class SnapControllerSender implements Sender {
-  #snapId: string;
+  #snapId: SnapId;
 
   #origin: string;
 
@@ -28,7 +29,7 @@ class SnapControllerSender implements Sender {
    */
   constructor(
     controller: any,
-    snapId: string,
+    snapId: SnapId,
     origin: string,
     handler: HandlerType,
   ) {
@@ -46,7 +47,7 @@ class SnapControllerSender implements Sender {
    */
   async send(request: JsonRpcRequest): Promise<Json> {
     return this.#controller.handleRequest({
-      snapId: this.#snapId as ValidatedSnapId,
+      snapId: this.#snapId,
       origin: this.#origin,
       handler: this.#handler,
       request,
@@ -76,12 +77,12 @@ export class KeyringSnapControllerClient extends KeyringClient {
    */
   constructor({
     controller,
-    snapId = 'undefined',
+    snapId = 'undefined' as SnapId,
     origin = 'metamask',
     handler = 'onKeyringRequest' as HandlerType,
   }: {
     controller: SnapController;
-    snapId?: string;
+    snapId?: SnapId;
     origin?: string;
     handler?: HandlerType;
   }) {
@@ -97,7 +98,7 @@ export class KeyringSnapControllerClient extends KeyringClient {
    * @returns A new instance of `KeyringSnapControllerClient` with the
    * specified snap ID.
    */
-  withSnapId(snapId: string): KeyringSnapControllerClient {
+  withSnapId(snapId: SnapId): KeyringSnapControllerClient {
     return new KeyringSnapControllerClient({
       controller: this.#controller,
       snapId,

--- a/src/snap-utils.ts
+++ b/src/snap-utils.ts
@@ -1,4 +1,4 @@
-import type { SnapsGlobalObject } from '@metamask/snaps-rpc-methods';
+import type { SnapsProvider } from '@metamask/snaps-sdk';
 import type { Json } from '@metamask/utils';
 
 import type { KeyringEvent } from './events';
@@ -11,7 +11,7 @@ import type { KeyringEvent } from './events';
  * @param data - The event data.
  */
 export async function emitSnapKeyringEvent(
-  snap: SnapsGlobalObject,
+  snap: SnapsProvider,
   event: KeyringEvent,
   data: Record<string, Json>,
 ): Promise<void> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6894,14 +6894,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"punycode@npm:^2.1.0":
-  version: 2.3.0
-  resolution: "punycode@npm:2.3.0"
-  checksum: 39f760e09a2a3bbfe8f5287cf733ecdad69d6af2fe6f97ca95f24b8921858b91e9ea3c9eeec6e08cede96181b3bb33f95c6ffd8c77e63986508aa2e8159fa200
-  languageName: node
-  linkType: hard
-
-"punycode@npm:^2.1.1":
+"punycode@npm:^2.1.0, punycode@npm:^2.1.1":
   version: 2.3.1
   resolution: "punycode@npm:2.3.1"
   checksum: bb0a0ceedca4c3c57a9b981b90601579058903c62be23c5e8e843d2c2d4148a3ecf029d5133486fb0e1822b098ba8bba09e89d6b21742d02fa26bda6441a6fb2

--- a/yarn.lock
+++ b/yarn.lock
@@ -1103,9 +1103,9 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/providers": ^13.0.0
-    "@metamask/snaps-controllers": ^3.1.0
-    "@metamask/snaps-rpc-methods": ^3.1.0
-    "@metamask/snaps-utils": ^3.0.0
+    "@metamask/snaps-controllers": ^3.4.0
+    "@metamask/snaps-sdk": ^1.1.0
+    "@metamask/snaps-utils": ^4.0.1
     "@metamask/utils": ^8.1.0
     "@types/jest": ^28.1.6
     "@types/node": ^16
@@ -1167,6 +1167,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/phishing-controller@npm:^7.0.0":
+  version: 7.0.1
+  resolution: "@metamask/phishing-controller@npm:7.0.1"
+  dependencies:
+    "@metamask/base-controller": ^3.2.3
+    "@metamask/controller-utils": ^5.0.2
+    "@types/punycode": ^2.1.0
+    eth-phishing-detect: ^1.2.0
+    punycode: ^2.1.1
+  checksum: 9d7b4db829ce78163bc308ef520382a4d3eb43597acf05b56e1f712c56dfc60b504f61f532ebdc656f9fbeb8c26f62b7cf075aef3c5d8263b993c628cc485d81
+  languageName: node
+  linkType: hard
+
 "@metamask/post-message-stream@npm:^7.0.0":
   version: 7.0.0
   resolution: "@metamask/post-message-stream@npm:7.0.0"
@@ -1223,20 +1236,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-controllers@npm:^3.1.0":
-  version: 3.1.1
-  resolution: "@metamask/snaps-controllers@npm:3.1.1"
+"@metamask/snaps-controllers@npm:^3.4.0":
+  version: 3.4.0
+  resolution: "@metamask/snaps-controllers@npm:3.4.0"
   dependencies:
     "@metamask/approval-controller": ^4.0.0
     "@metamask/base-controller": ^3.2.0
     "@metamask/json-rpc-engine": ^7.1.1
     "@metamask/object-multiplex": ^1.2.0
     "@metamask/permission-controller": ^5.0.0
+    "@metamask/phishing-controller": ^7.0.0
     "@metamask/post-message-stream": ^7.0.0
     "@metamask/rpc-errors": ^6.1.0
     "@metamask/snaps-registry": ^2.1.0
-    "@metamask/snaps-rpc-methods": ^3.1.0
-    "@metamask/snaps-utils": ^3.1.0
+    "@metamask/snaps-rpc-methods": ^4.0.0
+    "@metamask/snaps-sdk": ^1.0.0
+    "@metamask/snaps-utils": ^4.0.0
     "@metamask/utils": ^8.1.0
     "@xstate/fsm": ^2.0.0
     concat-stream: ^2.0.0
@@ -1248,11 +1263,11 @@ __metadata:
     readable-web-to-node-stream: ^3.0.2
     tar-stream: ^3.1.6
   peerDependencies:
-    "@metamask/snaps-execution-environments": ^3.1.0
+    "@metamask/snaps-execution-environments": ^3.3.0
   peerDependenciesMeta:
     "@metamask/snaps-execution-environments":
       optional: true
-  checksum: a4fb339916481111c8c68c043e0633141583ae3128ccb78dc08b824791a1de394e293b5c2909b0d18af2858e8cc1963e4afc3f43abd75b62ed43845f2c0ece3f
+  checksum: 1d24355c3d4049a2ce8c3d6090a44433291d67fe52c9aab43c5ba7616d15f1fb392d6c5e1d1991a44df38e7100bec395f8f16bd5199500277797e236d250ee76
   languageName: node
   linkType: hard
 
@@ -1267,36 +1282,39 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-rpc-methods@npm:^3.1.0":
-  version: 3.2.1
-  resolution: "@metamask/snaps-rpc-methods@npm:3.2.1"
+"@metamask/snaps-rpc-methods@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@metamask/snaps-rpc-methods@npm:4.0.0"
   dependencies:
     "@metamask/key-tree": ^9.0.0
     "@metamask/permission-controller": ^5.0.0
     "@metamask/rpc-errors": ^6.1.0
-    "@metamask/snaps-ui": ^3.1.0
-    "@metamask/snaps-utils": ^3.2.0
+    "@metamask/snaps-sdk": ^1.0.0
+    "@metamask/snaps-utils": ^4.0.0
     "@metamask/utils": ^8.1.0
     "@noble/hashes": ^1.3.1
     superstruct: ^1.0.3
-  checksum: 82307f12939cc074f3521b708b4d5bfdadc8d25d52e402d1abf7c7e9d28245bcf7518243dbbf7c269c1df3e1570410f5b10abe91c4b5ec0723b7d3af55baa64d
+  checksum: 555d068a726cfeddee8c2f0cbc41e48a285ab1ffe9ecdb10b9a18882f7d9ab7bf92773628f709239fb672a2b123c26d229982bb926221481ee7a71c0751f12c1
   languageName: node
   linkType: hard
 
-"@metamask/snaps-ui@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "@metamask/snaps-ui@npm:3.1.0"
+"@metamask/snaps-sdk@npm:^1.0.0, @metamask/snaps-sdk@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@metamask/snaps-sdk@npm:1.1.0"
   dependencies:
+    "@metamask/key-tree": ^9.0.0
+    "@metamask/providers": ^13.0.0
+    "@metamask/rpc-errors": ^6.1.0
     "@metamask/utils": ^8.1.0
     is-svg: ^4.4.0
     superstruct: ^1.0.3
-  checksum: a234217e961a103b89708d46732481e82c0778b3ebbecddabc9351eee48d082cdc231102442c3ae5c76aa33b24c24aad70e84fee9d7b492641f290a10c3211c1
+  checksum: bd4dd25959bab214c3f9c0235e3b94740f900ced64b0ca09afbdedff8d927ff127b8d009fed285359be1c057eb57dd27aa824a6b331026baae7c674bee75c6e2
   languageName: node
   linkType: hard
 
-"@metamask/snaps-utils@npm:^3.0.0, @metamask/snaps-utils@npm:^3.1.0, @metamask/snaps-utils@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "@metamask/snaps-utils@npm:3.2.0"
+"@metamask/snaps-utils@npm:^4.0.0, @metamask/snaps-utils@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@metamask/snaps-utils@npm:4.0.1"
   dependencies:
     "@babel/core": ^7.23.2
     "@babel/types": ^7.23.0
@@ -1305,7 +1323,7 @@ __metadata:
     "@metamask/permission-controller": ^5.0.0
     "@metamask/rpc-errors": ^6.1.0
     "@metamask/snaps-registry": ^2.1.0
-    "@metamask/snaps-ui": ^3.1.0
+    "@metamask/snaps-sdk": ^1.1.0
     "@metamask/utils": ^8.1.0
     "@noble/hashes": ^1.3.1
     "@scure/base": ^1.1.1
@@ -1319,7 +1337,7 @@ __metadata:
     ses: ^0.18.8
     superstruct: ^1.0.3
     validate-npm-package-name: ^5.0.0
-  checksum: 1e7ed6b0f0392c09708eb2537bc58ba41f5a55176741c1c79aeb11cb37e6976cc69c2010fec84618f21d50e84e33cfef056e19c55c50f76cc4e9f85bbf9ca2ae
+  checksum: 381a031b6ec5fe62cf3ecf2706f9de49820ba9a092ff16245fec60d56dbe665df793e5e7cb20777ef0cfebba56eec0610e9e2b520e2ba715bc3260f7e0d0df7e
   languageName: node
   linkType: hard
 
@@ -1803,6 +1821,13 @@ __metadata:
   version: 2.7.3
   resolution: "@types/prettier@npm:2.7.3"
   checksum: 705384209cea6d1433ff6c187c80dcc0b95d99d5c5ce21a46a9a58060c527973506822e428789d842761e0280d25e3359300f017fbe77b9755bc772ab3dc2f83
+  languageName: node
+  linkType: hard
+
+"@types/punycode@npm:^2.1.0":
+  version: 2.1.2
+  resolution: "@types/punycode@npm:2.1.2"
+  checksum: 2cf4573bbdc28f9935154e0981acd2671e58d20ba9f61866e776295cf7b314c041bfe1aee8a1610de958fe4c1e46c8013908813fa23a28e361d256e823a56105
   languageName: node
   linkType: hard
 
@@ -3851,6 +3876,15 @@ __metadata:
     idna-uts46-hx: ^2.3.1
     js-sha3: ^0.5.7
   checksum: 40ce4aeedaa4e7eb4485c8d8857457ecc46a4652396981d21b7e3a5f922d5beff63c71cb4b283c935293e530eba50b329d9248be3c433949c6bc40c850c202a3
+  languageName: node
+  linkType: hard
+
+"eth-phishing-detect@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "eth-phishing-detect@npm:1.2.0"
+  dependencies:
+    fast-levenshtein: ^2.0.6
+  checksum: 66a6a7c249ec8494e0360663596ce980ca75747cd202c47732eca0bfc7a97c6debbae359842e4f3e4ac7e6c44ab1f7f091c3aa7baa330449d3c1b7cc58608b71
   languageName: node
   linkType: hard
 
@@ -6864,6 +6898,13 @@ __metadata:
   version: 2.3.0
   resolution: "punycode@npm:2.3.0"
   checksum: 39f760e09a2a3bbfe8f5287cf733ecdad69d6af2fe6f97ca95f24b8921858b91e9ea3c9eeec6e08cede96181b3bb33f95c6ffd8c77e63986508aa2e8159fa200
+  languageName: node
+  linkType: hard
+
+"punycode@npm:^2.1.1":
+  version: 2.3.1
+  resolution: "punycode@npm:2.3.1"
+  checksum: bb0a0ceedca4c3c57a9b981b90601579058903c62be23c5e8e843d2c2d4148a3ecf029d5133486fb0e1822b098ba8bba09e89d6b21742d02fa26bda6441a6fb2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- The versions of `@metamask/snaps-controllers` and `@metamask/snaps-rpc-methods` that this package uses rely on `@metamask/snaps-ui`, which has recently been deprecated. The deprecation causes the dependencies audit on the extension to fail.
- Global objects have been moved out of `@metamask/snaps-rpc-methods` to `@metamask/snaps-sdk`. Specifically, `SnapsGlobalObject` was renamed to `SnapsProvider`.

Given these changes, this commit bumps `@metamask/snaps-controllers` and replaces `@metamask/snaps-rpc-methods` with `@metamask/snaps-sdk`, using `SnapsGlobalObject` instead of `SnapsProvider`.