### PR TITLE
Lavamoat config: Do not allow scripts for @swc/core

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
       "@metamask/snaps-utils>@metamask/base-controller>@metamask/controller-utils>ethereumjs-util>ethereum-cryptography>keccak": false,
       "@metamask/snaps-utils>@metamask/base-controller>@metamask/controller-utils>ethereumjs-util>ethereum-cryptography>secp256k1": false,
       "@metamask/snaps-utils>@metamask/permission-controller>@metamask/controller-utils>ethereumjs-util>ethereum-cryptography>keccak": false,
-      "@metamask/snaps-utils>@metamask/permission-controller>@metamask/controller-utils>ethereumjs-util>ethereum-cryptography>secp256k1": false
+      "@metamask/snaps-utils>@metamask/permission-controller>@metamask/controller-utils>ethereumjs-util>ethereum-cryptography>secp256k1": false,
+      "ts-node>@swc/core": false
     }
   }
 }


### PR DESCRIPTION
This resolves a lavamoat error reported in the metamask-docs repo (which imports this repo as a submodule)

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

Issue reported in docs repo: 

```
no allowed lifecycle scripts found in configuration
running lifecycle scripts for top level package
Error: command failed
    at ChildProcess.<anonymous> (/Users/consensys-cm/Documents/GitHub/metamask-docs/node_modules/@npmcli/promise-spawn/lib/index.js:53:27)
    at ChildProcess.emit (node:events:513:28)
    at maybeClose (node:internal/child_process:1098:16)
    at Socket.<anonymous> (node:internal/child_process:456:11)
    at Socket.emit (node:events:513:28)
    at Pipe.<anonymous> (node:net:332:12) {
  cmd: 'sh',
  args: [ '-c', 'cd external/keyring-api && yarn install' ],
  code: 1,
  signal: null,
  stdout: '➤ YN0000: ┌ Resolution step\n' +
    '➤ YN0000: └ Completed\n' +
    '➤ YN0000: ┌ Fetch step\n' +
    '➤ YN0000: └ Completed\n' +
    '➤ YN0000: ┌ Link step\n' +
    '➤ YN0000: └ Completed\n' +
    '\n' +
    '@lavamoat/allow-scripts has detected dependencies without configuration. explicit configuration required.\n' +
    'run "allow-scripts auto" to automatically populate the configuration.\n' +
    '\n' +
    'packages missing configuration:\n' +
    '- ts-node>@swc/core [1 location(s)]',
  stderr: '',
  event: 'postinstall',
  script: 'cd external/keyring-api && yarn install',
  pkgid: 'metamask-docs@0.0.0',
  path: '/Users/consensys-cm/Documents/GitHub/metamask-docs'
}
```

After updating the lavamoat config: 

```
➜  metamask-docs git:(main) cd external/keyring-api 
➜  keyring-api git:(v0.1.3) yarn allow-scripts auto

@lavamoat/allow-scripts automatically updating configuration

adding configuration:
- lifecycle ts-node>@swc/core
➜  keyring-api git:(v0.1.3) ✗ 
```

Error goes away. 