### PR TITLE
feat: update `eth_patchUserOperation` to return optional gas limit values

### DIFF
--- a/docs/diagrams/user_operation_signing.puml
+++ b/docs/diagrams/user_operation_signing.puml
@@ -77,6 +77,9 @@ MetaMask -> Snap ++: ""patchUserOperation({""\n\
 
 Snap --> MetaMask --: ""{""\n\
 ""  paymasterAndData?,""\n\
+""  callGasLimit?,""\n\
+""  verificationGasLimit?,""\n\
+""  preVerificationGas?,""\n\
 ""}""
 
 MetaMask -> MetaMask: Update ""paymasterAndData"" and\n\

--- a/docs/evm_methods_userOp.md
+++ b/docs/evm_methods_userOp.md
@@ -152,13 +152,13 @@ Patch _some_ allowed properties of an UserOperation.
       - Pattern: `^0x[0-9a-f]*$`
     - `callGasLimit` (optional)
       - Type: `string`
-      - Pattern: `^0x[0-9a-f]*$`
-    - `preverificationGas` (optional)
+      - Pattern: `^0x([1-9a-f][0-9a-f]*|0)$`
+    - `preVerificationGas` (optional)
       - Type: `string`
-      - Pattern: `^0x[0-9a-f]*$`
+      - Pattern: `^0x([1-9a-f][0-9a-f]*|0)$`
     - `verificationGasLimit` (optional)
       - Type: `string`
-      - Pattern: `^0x[0-9a-f]*$`
+      - Pattern: `^0x([1-9a-f][0-9a-f]*|0)$`
 
 ### Example
 

--- a/docs/evm_methods_userOp.md
+++ b/docs/evm_methods_userOp.md
@@ -150,6 +150,15 @@ Patch _some_ allowed properties of an UserOperation.
     - `paymasterAndData`
       - Type: `string`
       - Pattern: `^0x[0-9a-f]*$`
+    - `callGasLimit` (optional)
+      - Type: `string`
+      - Pattern: `^0x[0-9a-f]*$`
+    - `preverificationGas` (optional)
+      - Type: `string`
+      - Pattern: `^0x[0-9a-f]*$`
+    - `verificationGasLimit` (optional)
+      - Type: `string`
+      - Pattern: `^0x[0-9a-f]*$`
 
 ### Example
 
@@ -180,7 +189,10 @@ Patch _some_ allowed properties of an UserOperation.
 
 ```json
 {
-  "paymasterAndData": "0x952514d7cBCB495EACeB86e02154921401dB0Cd9dac17f958d2ee523a2206206994597c13d831ec700000000000000000000000000000000000000000000000000000000779b3fbb00000000000000006565b267000000000000000000000000000000000000000029195b31a9b1c6ccdeff53e359ebbcd5f075a93c1aaed93302e5fde5faf8047028b296b8a3fa4e22b063af5069ae9f656736ffda0ee090c0311155722b905f781b"
+  "paymasterAndData": "0x952514d7cBCB495EACeB86e02154921401dB0Cd9dac17f958d2ee523a2206206994597c13d831ec700000000000000000000000000000000000000000000000000000000779b3fbb00000000000000006565b267000000000000000000000000000000000000000029195b31a9b1c6ccdeff53e359ebbcd5f075a93c1aaed93302e5fde5faf8047028b296b8a3fa4e22b063af5069ae9f656736ffda0ee090c0311155722b905f781b",
+  "callGasLimit": "0x58a83",
+  "verificationGasLimit": "0xe8c4",
+  "preVerificationGas": "0xc57c"
 }
 ```
 

--- a/src/eth/erc4337/types.ts
+++ b/src/eth/erc4337/types.ts
@@ -1,4 +1,4 @@
-import { optional, string, type Infer } from 'superstruct';
+import { string, type Infer } from 'superstruct';
 
 import { exactOptional, object } from '../../superstruct';
 import { EthAddressStruct, EthBytesStruct, EthUint256Struct } from '../types';
@@ -66,9 +66,9 @@ export type EthBaseUserOperation = Infer<typeof EthBaseUserOperationStruct>;
 
 export const EthUserOperationPatchStruct = object({
   paymasterAndData: EthBytesStruct,
-  callDataLimit: optional(EthUint256Struct),
-  verificationGasLimit: optional(EthUint256Struct),
-  preVerificationGas: optional(EthUint256Struct),
+  callGasLimit: exactOptional(EthUint256Struct),
+  verificationGasLimit: exactOptional(EthUint256Struct),
+  preVerificationGas: exactOptional(EthUint256Struct),
 });
 
 export type EthUserOperationPatch = Infer<typeof EthUserOperationPatchStruct>;

--- a/src/eth/erc4337/types.ts
+++ b/src/eth/erc4337/types.ts
@@ -1,4 +1,4 @@
-import { string, type Infer } from 'superstruct';
+import { optional, string, type Infer } from 'superstruct';
 
 import { exactOptional, object } from '../../superstruct';
 import { EthAddressStruct, EthBytesStruct, EthUint256Struct } from '../types';
@@ -66,6 +66,9 @@ export type EthBaseUserOperation = Infer<typeof EthBaseUserOperationStruct>;
 
 export const EthUserOperationPatchStruct = object({
   paymasterAndData: EthBytesStruct,
+  callDataLimit: optional(EthUint256Struct),
+  verificationGasLimit: optional(EthUint256Struct),
+  preVerificationGas: optional(EthUint256Struct),
 });
 
 export type EthUserOperationPatch = Infer<typeof EthUserOperationPatchStruct>;


### PR DESCRIPTION
This PR update the docs and adds new optional return values during the PatchUserOperation.


* Fixes [#260](https://app.zenhub.com/workspaces/metamask-accounts-team-v2-64c91cbeaa9d1c00126621fd/issues/gh/metamask/accounts-planning/260) 
