### PR TITLE
docs: add `eth_decodeUserOperationCallData` to documentation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -209,16 +209,22 @@ participant Snap
 User ->>+ Dapp: Create new sign request
 Dapp ->>+ MetaMask: ethereum.request(request)
 alt Is EIP-4337 account?
-  MetaMask ->>+ Snap: keyring_prepareRequest(request)
+  MetaMask ->>+ Snap: keyring_submitRequest({request, method: eth_prepareUserOperation})
   Snap ->> Snap: Custom logic to prepare request
   Snap -->>- MetaMask: { request }
+  MetaMask ->>+ Snap: keyring_submitRequest({request, method: eth_patchUserOperation})
+  Snap -->>- MetaMask: { paymasterAndData?, calldata?, callGasLimit?, verificationGasLimit?, preVerificationGas? }
+  alt If calldata was changed
+    MetaMask ->>+ Snap: keyring_submitRequest({request, method: eth_decodeUserOperationCallData})
+    Snap -->>- MetaMask: { intents }
+  end
 end
 MetaMask ->> MetaMask: Display request to user
 User ->> MetaMask: Approve request
 
 MetaMask ->>+ Snap: keyring_submitRequest(request)
 Snap ->> Snap: Custom logic to handle request
-Snap -->>- MetaMask: { pendind: false, result }
+Snap -->>- MetaMask: { pending: false, result }
 
 MetaMask -->>- Dapp: result
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -163,11 +163,6 @@ participant Site as Snap Companion Dapp
 
 User ->>+ Dapp: Create new sign request
 Dapp ->>+ MetaMask: ethereum.request(request)
-alt Is EIP-4337 account?
-  MetaMask ->>+ Snap: keyring_prepareRequest(request)
-  Snap ->> Snap: Custom logic to prepare request
-  Snap -->>- MetaMask: { request }
-end
 MetaMask ->> MetaMask: Display request to user
 User ->> MetaMask: Approve request
 

--- a/docs/diagrams/user_operation_signing.puml
+++ b/docs/diagrams/user_operation_signing.puml
@@ -85,6 +85,22 @@ Snap --> MetaMask --: ""{""\n\
 MetaMask -> MetaMask: Update ""paymasterAndData"" and\n\
 remove the dummy signature
 
+alt Calldata has been changed
+MetaMask -> Snap ++: ""eth_decodeUserOperationCallData({""\n\
+""  callData,""\n\
+""})""
+Snap --> MetaMask --: ""{""\n\
+""  intents: [ // List of transactions""\n\
+""    {""\n\
+""      to,""\n\
+""      value,""\n\
+""      data,""\n\
+""    },""\n\
+""  ]""\n\
+})
+end
+
+
 MetaMask -> MetaMask: Display approval UI
 
 MetaMask -> Snap ++: ""signUserOperation([""\n\

--- a/docs/evm_methods_userOp.md
+++ b/docs/evm_methods_userOp.md
@@ -280,4 +280,59 @@ Sign an UserOperation.
 "0x6565acc7efd3c85e4c0c221c2958ff6c3ae68401b23b33fdcd1a2d49034c30d97b1cfa17487b90253a5dfd54ef5188688592c2fd56ba44ee4d948ea259d636cd550f6dd21b"
 ```
 
+## eth_decodeUserOperationCallData
+
+### Parameters (Array)
+
+1. **Call data**
+   - Type: `string`
+   - Pattern: `^0x[0-9a-f]*$`
+
+### Returns
+
+- **Transaction Intents**
+  - Type: `array`
+  - Properties:
+    - Type: `object`
+    - Properties:
+    - `to`
+      - Type: `string`
+      - Pattern: `^0x[0-9a-fA-F]{40}$`
+    - `value`
+      - Type: `string`
+      - Pattern: `^0x([1-9a-f][0-9a-f]*|0)$`
+    - `data`
+      - Type: `string`
+      - Pattern: `^0x[0-9a-f]*$`
+
+### Example
+
+**Request:**
+
+```json
+{
+  "method": "eth_decodeUserOperationCallData",
+  "params": [
+    "0x70641a22000000000000000000000000f3de3c0d654fda23dad170f0f320a921725091270"
+  ]
+}
+```
+
+**Response:**
+
+```json
+[
+  {
+    "to": "0x0c54fccd2e384b4bb6f2e405bf5cbc15a017aafb",
+    "value": "0x1234",
+    "data": "0x"
+  },
+  {
+    "to": "0x660265edc169bab511a40c0e049cc1e33774443d",
+    "value": "0x0",
+    "data": "0x619a309f"
+  }
+]
+```
+
 [erc-4337]: https://eips.ethereum.org/EIPS/eip-4337


### PR DESCRIPTION
This method takes the `callData` as input and returns the transaction intents that were encoded in it.