### PR TITLE
fix: bundler URL validation

### DIFF
--- a/src/eth/erc4337/types.test.ts
+++ b/src/eth/erc4337/types.test.ts
@@ -105,7 +105,7 @@ describe('types', () => {
         bundlerUrl: 'random string',
       };
       expect(() => assert(userOp, EthBaseUserOperationStruct)).toThrow(
-        'At path: bundlerUrl -- Expected a value of type `string`, but received: `"random string"`',
+        'At path: bundlerUrl -- Expected a value of type `Url`, but received: `"random string"`',
       );
     });
 
@@ -115,7 +115,7 @@ describe('types', () => {
         bundlerUrl: '',
       };
       expect(() => assert(userOp, EthBaseUserOperationStruct)).toThrow(
-        'At path: bundlerUrl -- Expected a value of type `string`, but received: `""`',
+        'At path: bundlerUrl -- Expected a value of type `Url`, but received: `""`',
       );
     });
 

--- a/src/eth/erc4337/types.test.ts
+++ b/src/eth/erc4337/types.test.ts
@@ -110,7 +110,7 @@ describe('types', () => {
         bundlerUrl: 'random string',
       };
       expect(() => assert(userOp, EthBaseUserOperationStruct)).toThrow(
-        'At path: bundlerUrl -- Expected a value of type `BundlerUrl`, but received: `"random string"`',
+        'At path: bundlerUrl -- Expected a value of type `string`, but received: `"random string"`',
       );
     });
 
@@ -129,7 +129,7 @@ describe('types', () => {
         bundlerUrl: '',
       };
       expect(() => assert(userOp, EthBaseUserOperationStruct)).toThrow(
-        'At path: bundlerUrl -- Expected a value of type `BundlerUrl`, but received: `""`',
+        'At path: bundlerUrl -- Expected a value of type `string`, but received: `""`',
       );
     });
 

--- a/src/eth/erc4337/types.test.ts
+++ b/src/eth/erc4337/types.test.ts
@@ -1,6 +1,6 @@
 import { assert } from 'superstruct';
 
-import { EthUserOperationStruct } from './types';
+import { EthUserOperationStruct, EthBaseUserOperationStruct } from './types';
 
 describe('types', () => {
   it('is a valid UserOperation', () => {
@@ -75,5 +75,74 @@ describe('types', () => {
     expect(() => assert(userOp, EthUserOperationStruct)).toThrow(
       'At path: nonce -- Expected a value of type `EthUint256`, but received: `"0x01"`',
     );
+  });
+
+  describe('EthBaseUserOperationStruct', () => {
+    it('is a valid BaseUserOperation', () => {
+      const userOp = {
+        nonce: '0x1',
+        initCode: '0x',
+        callData: '0x70641a22000000000000000000000000',
+        gasLimits: {
+          callGasLimit: '0x58a83',
+          verificationGasLimit: '0xe8c4',
+          preVerificationGas: '0xc57c',
+        },
+        dummyPaymasterAndData: '0x1234',
+        dummySignature: '0x1234',
+        bundlerUrl: 'https://example.com',
+      };
+      expect(() => assert(userOp, EthBaseUserOperationStruct)).not.toThrow();
+    });
+
+    it('has an invalid BaseUserOperation with an incorrect url string', () => {
+      const userOp = {
+        nonce: '0x1',
+        initCode: '0x',
+        callData: '0x70641a22000000000000000000000000',
+        gasLimits: {
+          callGasLimit: '0x58a83',
+          verificationGasLimit: '0xe8c4',
+          preVerificationGas: '0xc57c',
+        },
+        dummyPaymasterAndData: '0x1234',
+        dummySignature: '0x1234',
+        bundlerUrl: 'random string',
+      };
+      expect(() => assert(userOp, EthBaseUserOperationStruct)).toThrow(
+        'At path: bundlerUrl -- Expected a value of type `BundlerUrl`, but received: `"random string"`',
+      );
+    });
+
+    it('cannot have an empty bundler url', () => {
+      const userOp = {
+        nonce: '0x1',
+        initCode: '0x',
+        callData: '0x70641a22000000000000000000000000',
+        gasLimits: {
+          callGasLimit: '0x58a83',
+          verificationGasLimit: '0xe8c4',
+          preVerificationGas: '0xc57c',
+        },
+        dummyPaymasterAndData: '0x1234',
+        dummySignature: '0x1234',
+        bundlerUrl: '',
+      };
+      expect(() => assert(userOp, EthBaseUserOperationStruct)).toThrow(
+        'At path: bundlerUrl -- Expected a value of type `BundlerUrl`, but received: `""`',
+      );
+    });
+
+    it('does not throw if gasLimits are undefined', () => {
+      const userOp = {
+        nonce: '0x1',
+        initCode: '0x',
+        callData: '0x70641a22000000000000000000000000',
+        dummyPaymasterAndData: '0x1234',
+        dummySignature: '0x1234',
+        bundlerUrl: 'https://example.com',
+      };
+      expect(() => assert(userOp, EthBaseUserOperationStruct)).not.toThrow();
+    });
   });
 });

--- a/src/eth/erc4337/types.test.ts
+++ b/src/eth/erc4337/types.test.ts
@@ -78,18 +78,22 @@ describe('types', () => {
   });
 
   describe('EthBaseUserOperationStruct', () => {
+    const baseUserOp = {
+      nonce: '0x1',
+      initCode: '0x',
+      callData: '0x70641a22000000000000000000000000',
+      gasLimits: {
+        callGasLimit: '0x58a83',
+        verificationGasLimit: '0xe8c4',
+        preVerificationGas: '0xc57c',
+      },
+      dummyPaymasterAndData: '0x1234',
+      dummySignature: '0x1234',
+    };
+
     it('is a valid BaseUserOperation', () => {
       const userOp = {
-        nonce: '0x1',
-        initCode: '0x',
-        callData: '0x70641a22000000000000000000000000',
-        gasLimits: {
-          callGasLimit: '0x58a83',
-          verificationGasLimit: '0xe8c4',
-          preVerificationGas: '0xc57c',
-        },
-        dummyPaymasterAndData: '0x1234',
-        dummySignature: '0x1234',
+        ...baseUserOp,
         bundlerUrl: 'https://example.com',
       };
       expect(() => assert(userOp, EthBaseUserOperationStruct)).not.toThrow();
@@ -97,16 +101,7 @@ describe('types', () => {
 
     it('has an invalid BaseUserOperation with an incorrect url string', () => {
       const userOp = {
-        nonce: '0x1',
-        initCode: '0x',
-        callData: '0x70641a22000000000000000000000000',
-        gasLimits: {
-          callGasLimit: '0x58a83',
-          verificationGasLimit: '0xe8c4',
-          preVerificationGas: '0xc57c',
-        },
-        dummyPaymasterAndData: '0x1234',
-        dummySignature: '0x1234',
+        ...baseUserOp,
         bundlerUrl: 'random string',
       };
       expect(() => assert(userOp, EthBaseUserOperationStruct)).toThrow(
@@ -116,16 +111,7 @@ describe('types', () => {
 
     it('cannot have an empty bundler url', () => {
       const userOp = {
-        nonce: '0x1',
-        initCode: '0x',
-        callData: '0x70641a22000000000000000000000000',
-        gasLimits: {
-          callGasLimit: '0x58a83',
-          verificationGasLimit: '0xe8c4',
-          preVerificationGas: '0xc57c',
-        },
-        dummyPaymasterAndData: '0x1234',
-        dummySignature: '0x1234',
+        ...baseUserOp,
         bundlerUrl: '',
       };
       expect(() => assert(userOp, EthBaseUserOperationStruct)).toThrow(

--- a/src/eth/erc4337/types.ts
+++ b/src/eth/erc4337/types.ts
@@ -1,7 +1,12 @@
-import { string, type Infer } from 'superstruct';
+import { type Infer } from 'superstruct';
 
 import { exactOptional, object } from '../../superstruct';
-import { EthAddressStruct, EthBytesStruct, EthUint256Struct } from '../types';
+import {
+  BundlerUrlStruct,
+  EthAddressStruct,
+  EthBytesStruct,
+  EthUint256Struct,
+} from '../types';
 
 /**
  * Struct of a UserOperation as defined by ERC-4337.
@@ -59,7 +64,7 @@ export const EthBaseUserOperationStruct = object({
   ),
   dummyPaymasterAndData: EthBytesStruct,
   dummySignature: EthBytesStruct,
-  bundlerUrl: string(),
+  bundlerUrl: BundlerUrlStruct,
 });
 
 export type EthBaseUserOperation = Infer<typeof EthBaseUserOperationStruct>;

--- a/src/eth/erc4337/types.ts
+++ b/src/eth/erc4337/types.ts
@@ -1,12 +1,7 @@
 import { type Infer } from 'superstruct';
 
-import { exactOptional, object } from '../../superstruct';
-import {
-  BundlerUrlStruct,
-  EthAddressStruct,
-  EthBytesStruct,
-  EthUint256Struct,
-} from '../types';
+import { UrlStruct, exactOptional, object } from '../../superstruct';
+import { EthAddressStruct, EthBytesStruct, EthUint256Struct } from '../types';
 
 /**
  * Struct of a UserOperation as defined by ERC-4337.
@@ -64,7 +59,7 @@ export const EthBaseUserOperationStruct = object({
   ),
   dummyPaymasterAndData: EthBytesStruct,
   dummySignature: EthBytesStruct,
-  bundlerUrl: BundlerUrlStruct,
+  bundlerUrl: UrlStruct,
 });
 
 export type EthBaseUserOperation = Infer<typeof EthBaseUserOperationStruct>;

--- a/src/eth/types.test.ts
+++ b/src/eth/types.test.ts
@@ -1,0 +1,30 @@
+import { BundlerUrlStruct } from './types';
+
+describe('types', () => {
+  it('is a valid BundlerUrl', () => {
+    const url = 'https://api.example.com';
+    expect(() => BundlerUrlStruct.assert(url)).not.toThrow();
+  });
+
+  it('is a valid BundlerUrl with query parameters', () => {
+    const url = 'https://api.example.com?foo=bar';
+    expect(() => BundlerUrlStruct.assert(url)).not.toThrow();
+  });
+
+  it('accepts path parameters', () => {
+    const url = 'https://api.example.com/foo/bar';
+    expect(() => BundlerUrlStruct.assert(url)).not.toThrow();
+  });
+
+  it('fails if it does not start with http or https', () => {
+    const url = 'ftp://api.example.com';
+    expect(() => BundlerUrlStruct.assert(url)).toThrow(
+      'Expected a value of type `BundlerUrl`, but received: `"ftp://api.example.com"`',
+    );
+  });
+
+  it('has to start with http or https', () => {
+    const url = 'http://api.example.com';
+    expect(() => BundlerUrlStruct.assert(url)).not.toThrow();
+  });
+});

--- a/src/eth/types.test.ts
+++ b/src/eth/types.test.ts
@@ -1,30 +1,30 @@
-import { BundlerUrlStruct } from './types';
+import { UrlStruct } from '../superstruct';
 
 describe('types', () => {
   it('is a valid BundlerUrl', () => {
     const url = 'https://api.example.com';
-    expect(() => BundlerUrlStruct.assert(url)).not.toThrow();
+    expect(() => UrlStruct.assert(url)).not.toThrow();
   });
 
   it('is a valid BundlerUrl with query parameters', () => {
     const url = 'https://api.example.com?foo=bar';
-    expect(() => BundlerUrlStruct.assert(url)).not.toThrow();
+    expect(() => UrlStruct.assert(url)).not.toThrow();
   });
 
   it('accepts path parameters', () => {
     const url = 'https://api.example.com/foo/bar';
-    expect(() => BundlerUrlStruct.assert(url)).not.toThrow();
+    expect(() => UrlStruct.assert(url)).not.toThrow();
   });
 
   it('fails if it does not start with http or https', () => {
     const url = 'ftp://api.example.com';
-    expect(() => BundlerUrlStruct.assert(url)).toThrow(
-      'Expected a value of type `string`, but received: `"ftp://api.example.com"`',
+    expect(() => UrlStruct.assert(url)).toThrow(
+      'Expected a value of type `Url`, but received: `"ftp://api.example.com"`',
     );
   });
 
   it('has to start with http or https', () => {
     const url = 'http://api.example.com';
-    expect(() => BundlerUrlStruct.assert(url)).not.toThrow();
+    expect(() => UrlStruct.assert(url)).not.toThrow();
   });
 });

--- a/src/eth/types.test.ts
+++ b/src/eth/types.test.ts
@@ -19,7 +19,7 @@ describe('types', () => {
   it('fails if it does not start with http or https', () => {
     const url = 'ftp://api.example.com';
     expect(() => BundlerUrlStruct.assert(url)).toThrow(
-      'Expected a value of type `BundlerUrl`, but received: `"ftp://api.example.com"`',
+      'Expected a value of type `string`, but received: `"ftp://api.example.com"`',
     );
   });
 

--- a/src/eth/types.ts
+++ b/src/eth/types.ts
@@ -1,5 +1,3 @@
-import { refine, string } from 'superstruct';
-
 import { definePattern } from '../superstruct';
 
 export const EthBytesStruct = definePattern('EthBytes', /^0x[0-9a-f]*$/iu);
@@ -12,20 +10,4 @@ export const EthAddressStruct = definePattern(
 export const EthUint256Struct = definePattern(
   'EthUint256',
   /^0x([1-9a-f][0-9a-f]*|0)$/iu,
-);
-
-export const BundlerUrlStruct = refine(
-  string(),
-  'BundlerUrl',
-  (value: string) => {
-    let url;
-
-    try {
-      url = new URL(value);
-    } catch (_) {
-      return false;
-    }
-
-    return url.protocol === 'http:' || url.protocol === 'https:';
-  },
 );

--- a/src/eth/types.ts
+++ b/src/eth/types.ts
@@ -1,3 +1,4 @@
+import { refine, string } from 'superstruct';
 import { definePattern } from '../superstruct';
 
 export const EthBytesStruct = definePattern('EthBytes', /^0x[0-9a-f]*$/iu);
@@ -12,7 +13,18 @@ export const EthUint256Struct = definePattern(
   /^0x([1-9a-f][0-9a-f]*|0)$/iu,
 );
 
-export const BundlerUrlStruct = definePattern(
+export const BundlerUrlStruct = refine(
+  string(),
   'BundlerUrl',
-  /^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\\+.~#?&\\/=]*)$/iu,
+  (value: string) => {
+    let url;
+
+    try {
+      url = new URL(value);
+    } catch (_) {
+      return false;
+    }
+
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  },
 );

--- a/src/eth/types.ts
+++ b/src/eth/types.ts
@@ -1,4 +1,5 @@
 import { refine, string } from 'superstruct';
+
 import { definePattern } from '../superstruct';
 
 export const EthBytesStruct = definePattern('EthBytes', /^0x[0-9a-f]*$/iu);

--- a/src/eth/types.ts
+++ b/src/eth/types.ts
@@ -11,3 +11,8 @@ export const EthUint256Struct = definePattern(
   'EthUint256',
   /^0x([1-9a-f][0-9a-f]*|0)$/iu,
 );
+
+export const BundlerUrlStruct = definePattern(
+  'BundlerUrl',
+  /^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\\+.~#?&\\/=]*)$/iu,
+);

--- a/src/superstruct.ts
+++ b/src/superstruct.ts
@@ -125,3 +125,21 @@ export function definePattern(
       typeof value === 'string' && pattern.test(value),
   );
 }
+
+/**
+ * Validates if a given value is a valid URL.
+ *
+ * @param value - The value to be validated.
+ * @returns A boolean indicating if the value is a valid URL.
+ */
+export const UrlStruct = define('Url', (value: unknown) => {
+  let url;
+
+  try {
+    url = new URL(value as string);
+  } catch (_) {
+    return false;
+  }
+
+  return url.protocol === 'http:' || url.protocol === 'https:';
+});


### PR DESCRIPTION
This PR adds validation for the bundler url returned in the `PrepareUserOperation` step. Prior to this PR, the bundler value accepts any string. 

* Fixes [#289](https://github.com/MetaMask/accounts-planning/issues/289)

