### PR TITLE
docs: add note to `eth_prepareUserOperation` method response

### DIFF
--- a/docs/evm_methods_userOp.md
+++ b/docs/evm_methods_userOp.md
@@ -7,6 +7,8 @@ requests using [ERC-4337][erc-4337] accounts.
 
 Prepare a new UserOperation from transaction data.
 
+Note: The return value of this method requires the properties `dummySignature` and `dummyPaymasterAndData`. This is necessary because the UserOperation needs its total size in bytes to be determined in order to accurately estimate the gas costs from the bundler.
+
 ### Parameters (Array)
 
 1. **Transaction Intents (repeated, required)**

--- a/docs/evm_methods_userOp.md
+++ b/docs/evm_methods_userOp.md
@@ -7,7 +7,7 @@ requests using [ERC-4337][erc-4337] accounts.
 
 Prepare a new UserOperation from transaction data.
 
-Note: The return value of this method requires the properties `dummySignature` and `dummyPaymasterAndData`. This is necessary because the UserOperation needs its total size in bytes to be determined in order to accurately estimate the gas costs from the bundler.
+> ✏️ **Note:** The return value of this method requires the properties `dummySignature` and `dummyPaymasterAndData`. This is necessary because the UserOperation needs its total size in bytes to be determined in order to accurately estimate the gas costs from the bundler.
 
 ### Parameters (Array)
 


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

This change just adds a minor note to clarify the need of having `dummySignature` and `dummyPaymasterAndData` as part of the response of `eth_prepareUserOperation`.

