### PR TITLE
chore: bump dependencies

### DIFF
--- a/docs/evm_methods_userOp.md
+++ b/docs/evm_methods_userOp.md
@@ -7,6 +7,8 @@ requests using [ERC-4337][erc-4337] accounts.
 
 Prepare a new UserOperation from transaction data.
 
+> ✏️ **Note:** The return value of this method requires the properties `dummySignature` and `dummyPaymasterAndData`. This is necessary because the UserOperation needs its total size in bytes to be determined in order to accurately estimate the gas costs from the bundler.
+
 ### Parameters (Array)
 
 1. **Transaction Intents (repeated, required)**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1012,13 +1012,13 @@ __metadata:
   linkType: hard
 
 "@metamask/json-rpc-engine@npm:^7.1.1":
-  version: 7.3.2
-  resolution: "@metamask/json-rpc-engine@npm:7.3.2"
+  version: 7.3.3
+  resolution: "@metamask/json-rpc-engine@npm:7.3.3"
   dependencies:
-    "@metamask/rpc-errors": ^6.1.0
+    "@metamask/rpc-errors": ^6.2.1
     "@metamask/safe-event-emitter": ^3.0.0
     "@metamask/utils": ^8.3.0
-  checksum: 396861afc72944af410d5b06c81806db2fd9812206dbf799438f42d974edac6931f6814133adf52d6aa233d5ea3f3629663ef4f54a0cf9ccb948ce9b527137fd
+  checksum: 7bab8b4d2341a6243ba451bc58283f0a6905b09f7257857859848a51a795444ca6899b1a6908b15f8ed236fb574ab85a630c9cb28d127ab52c4630e496c16006
   languageName: node
   linkType: hard
 
@@ -1109,7 +1109,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/rpc-errors@npm:^6.0.0, @metamask/rpc-errors@npm:^6.1.0, @metamask/rpc-errors@npm:^6.2.1":
+"@metamask/rpc-errors@npm:^6.0.0, @metamask/rpc-errors@npm:^6.2.1":
   version: 6.2.1
   resolution: "@metamask/rpc-errors@npm:6.2.1"
   dependencies:


### PR DESCRIPTION
This PR bumps the following dependencies: `@metamask/providers`, `@metamask/snaps-sdk` and `@metamask/utils`
