### PR TITLE
feat!: add KeyringExecutionContext to user ops methods

### DIFF
--- a/src/contexts.ts
+++ b/src/contexts.ts
@@ -1,0 +1,7 @@
+/**
+ * Context used by a Keyring implementation.
+ */
+export type KeyringExecutionContext = {
+  /** The chain ID. */
+  chainId: string;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './api';
+export * from './contexts';
 export * from './eth';
 export * from './events';
 export * from './internal';

--- a/src/internal/eth/EthKeyring.ts
+++ b/src/internal/eth/EthKeyring.ts
@@ -1,5 +1,6 @@
 import type { Json, Keyring } from '@metamask/utils';
 
+import type { KeyringExecutionContext } from '../../contexts';
 import type {
   EthBaseTransaction,
   EthBaseUserOperation,
@@ -13,11 +14,13 @@ export type EthKeyring<State extends Json> = Keyring<State> & {
    *
    * @param address - Address of the sender.
    * @param transactions - Base transactions to include in the UserOperation.
+   * @param context - Keyring execution context.
    * @returns A pseudo-UserOperation that can be used to construct a real.
    */
   prepareUserOperation?(
     address: string,
     transactions: EthBaseTransaction[],
+    context: KeyringExecutionContext,
   ): Promise<EthBaseUserOperation>;
 
   /**
@@ -26,11 +29,13 @@ export type EthKeyring<State extends Json> = Keyring<State> & {
    *
    * @param address - Address of the sender.
    * @param userOp - UserOperation to patch.
+   * @param context - Keyring execution context.
    * @returns A patch to apply to the UserOperation.
    */
   patchUserOperation?(
     address: string,
     userOp: EthUserOperation,
+    context: KeyringExecutionContext,
   ): Promise<EthUserOperationPatch>;
 
   /**
@@ -38,10 +43,12 @@ export type EthKeyring<State extends Json> = Keyring<State> & {
    *
    * @param address - Address of the sender.
    * @param userOp - UserOperation to sign.
+   * @param context - Keyring execution context.
    * @returns The signature of the UserOperation.
    */
   signUserOperation?(
     address: string,
     userOp: EthUserOperation,
+    context: KeyringExecutionContext,
   ): Promise<string>;
 };


### PR DESCRIPTION
## Description

Adding an additional parameter about the "execution context" (contains only `chainId` for now) for User operations methods. This will also help computing the CAIP-2 scope/chain-id for underlying calls later on.

### Related to

- [ ] metamask/accounts-planning/issues/307