### PR TITLE
ci: add stale workflow to close issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,15 @@
+name: 'Close stale issues and PRs'
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          days-before-stale: 30
+          days-before-close: 7


### PR DESCRIPTION
This pull request adds a stale workflow to automatically close stale issues and pull requests. The workflow runs on a schedule and checks for issues and pull requests that have been open for 30 days with no activity. If an issue or pull request is found to be stale, a comment is added with a warning message. If the stale label or comment is not removed within 7 days, the issue or pull request will be automatically closed.