### PR TITLE
refactor: remove dependency to @metamask/providers + use local BaseProvider type

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/providers": "^16.0.0",
     "@metamask/snaps-sdk": "^3.1.1",
     "@metamask/utils": "^8.3.0",
     "@types/uuid": "^9.0.1",

--- a/src/KeyringSnapRpcClient.ts
+++ b/src/KeyringSnapRpcClient.ts
@@ -1,4 +1,4 @@
-import type { MetaMaskInpageProvider } from '@metamask/providers';
+import type { SnapsEthereumProvider } from '@metamask/snaps-sdk';
 import type { Json } from '@metamask/utils';
 
 import type { JsonRpcRequest } from './JsonRpcRequest';
@@ -12,15 +12,15 @@ import { KeyringClient } from './KeyringClient';
 export class SnapRpcSender implements Sender {
   #origin: string;
 
-  #provider: MetaMaskInpageProvider;
+  #provider: SnapsEthereumProvider;
 
   /**
    * Create a new instance of `SnapRpcSender`.
    *
    * @param origin - The caller's origin.
-   * @param provider - The `MetaMaskInpageProvider` instance to use.
+   * @param provider - The provider instance to use.
    */
-  constructor(origin: string, provider: MetaMaskInpageProvider) {
+  constructor(origin: string, provider: SnapsEthereumProvider) {
     this.#origin = origin;
     this.#provider = provider;
   }
@@ -51,9 +51,9 @@ export class KeyringSnapRpcClient extends KeyringClient {
    * Create a new instance of `KeyringSnapRpcClient`.
    *
    * @param origin - Caller's origin.
-   * @param provider - The `MetaMaskInpageProvider` instance to use.
+   * @param provider - The provider instance to use.
    */
-  constructor(origin: string, provider: MetaMaskInpageProvider) {
+  constructor(origin: string, provider: SnapsEthereumProvider) {
     super(new SnapRpcSender(origin, provider));
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1059,7 +1059,6 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/providers": ^16.0.0
     "@metamask/snaps-sdk": ^3.1.1
     "@metamask/utils": ^8.3.0
     "@types/jest": ^28.1.6
@@ -1118,26 +1117,6 @@ __metadata:
     readable-stream: ^3.6.2
     webextension-polyfill: ^0.10.0
   checksum: 42571450e79d69d943384f557f6a61e0f73101d49804fb6e8075d791959f76c42b8ff626f711d434674792d77aead6cb8a32b04a3dcd53598c8aff24cbb1ad25
-  languageName: node
-  linkType: hard
-
-"@metamask/providers@npm:^16.0.0":
-  version: 16.0.0
-  resolution: "@metamask/providers@npm:16.0.0"
-  dependencies:
-    "@metamask/json-rpc-engine": ^7.3.2
-    "@metamask/json-rpc-middleware-stream": ^6.0.2
-    "@metamask/object-multiplex": ^2.0.0
-    "@metamask/rpc-errors": ^6.2.1
-    "@metamask/safe-event-emitter": ^3.0.0
-    "@metamask/utils": ^8.3.0
-    detect-browser: ^5.2.0
-    extension-port-stream: ^3.0.0
-    fast-deep-equal: ^3.1.3
-    is-stream: ^2.0.0
-    readable-stream: ^3.6.2
-    webextension-polyfill: ^0.10.0
-  checksum: cdc06796111edbf01e9aa8498170f7ffa3c68a4c0f66a629e3b0f7d37ee60eb32d83ee12f285c3d974d971c6af16a3fba531fb5733f5fa9412a18e1d3f648539
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

I was having a hard time with some incompatible versions of the `@metamask/providers` that we might have when mixing both the `keyring-api` updates and `snaps-sdk`.

To avoid such problems in the future, we can break this dependency by re-declaring a local "sufficient" type for our use for "providers".