### PR TITLE
refactor: use @metamask/providers as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/providers": "^16.0.0",
     "@metamask/snaps-sdk": "^3.1.1",
     "@metamask/utils": "^8.3.0",
     "@types/uuid": "^9.0.1",
@@ -53,6 +52,7 @@
     "@metamask/eslint-config-jest": "^12.1.0",
     "@metamask/eslint-config-nodejs": "^12.1.0",
     "@metamask/eslint-config-typescript": "^12.1.0",
+    "@metamask/providers": "^16.0.0",
     "@types/jest": "^28.1.6",
     "@types/node": "^16",
     "@typescript-eslint/eslint-plugin": "^5.43.0",
@@ -76,6 +76,9 @@
     "tsd": "^0.29.0",
     "typedoc": "^0.23.15",
     "typescript": "~4.8.4"
+  },
+  "peerDependencies": {
+    "@metamask/providers": ">=15 <17"
   },
   "packageManager": "yarn@3.2.1",
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1088,6 +1088,8 @@ __metadata:
     typedoc: ^0.23.15
     typescript: ~4.8.4
     uuid: ^9.0.0
+  peerDependencies:
+    "@metamask/providers": ">=15 <17"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description

Avoid declaring a version for `@metamask/providers` and use the one coming with the `snaps-sdk`.

For now the latest version of providers is `16.0.0`, so we use a quite "wide" opened range that should be enough until the next major bump of the providers.