### PR TITLE
Breaking: Add importTime property to InternalAccount metadata

### DIFF
--- a/src/internal/types.test.ts
+++ b/src/internal/types.test.ts
@@ -15,6 +15,7 @@ describe('InternalAccount', () => {
           type: 'Test Keyring',
         },
         name: 'Account 1',
+        importTime: 1713153716,
       },
     };
 
@@ -31,6 +32,7 @@ describe('InternalAccount', () => {
       metadata: {
         keyring: {},
         name: 'Account 1',
+        importTime: 1713153716,
       },
     };
 
@@ -48,6 +50,7 @@ describe('InternalAccount', () => {
       type: 'eip155:eoa',
       metadata: {
         name: 'Account 1',
+        importTime: 1713153716,
       },
     };
 
@@ -82,6 +85,7 @@ describe('InternalAccount', () => {
           type: 'Test Keyring',
         },
         name: 'Account 1',
+        importTime: 1713153716,
         extra: 'field',
       },
     };
@@ -103,6 +107,7 @@ describe('InternalAccount', () => {
           type: 'Test Keyring',
         },
         name: 'Account 1',
+        importTime: 1713153716,
         snap: {
           id: 'test-snap',
           enabled: true,
@@ -128,6 +133,7 @@ describe('InternalAccount', () => {
             type: 'Test Keyring',
           },
           name: 'Account 1',
+          importTime: 1713153716,
           snap: {
             id: 'test-snap',
             enabled: true,

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -16,6 +16,7 @@ export const InternalAccountStruct = object({
       }),
     ),
     lastSelected: exactOptional(number()),
+    importTime: number(),
     keyring: object({
       type: string(),
     }),


### PR DESCRIPTION
This pull request adds a new property, importTime, to the metadata of the InternalAccount struct. This property will store the import time of the account.

Resolves: 
#288 