### PR TITLE
feat: add `accountNameSuggestion` field to the `AccountCreatedEvent`

### DIFF
--- a/src/internal/events.ts
+++ b/src/internal/events.ts
@@ -1,5 +1,5 @@
 import { JsonStruct } from '@metamask/utils';
-import { boolean, literal, object } from 'superstruct';
+import { boolean, literal, object, string } from 'superstruct';
 
 import { KeyringAccountStruct } from '../api';
 import { KeyringEvent } from '../events';
@@ -13,6 +13,15 @@ export const AccountCreatedEventStruct = object({
      * New account object.
      */
     account: KeyringAccountStruct,
+
+    /**
+     * Account name suggestion provided to the MetaMask client.
+     *
+     * The keyring can suggest a name for the account, but it's up to the
+     * client to decide whether to use it. The keyring won't be informed if the
+     * client decides to use a different name.
+     */
+    accountNameSuggestion: exactOptional(string()),
 
     /**
      * Instructs MetaMask to display the add account confirmation dialog in the UI.


### PR DESCRIPTION
This PR adds an `accountNameSuggestion` field to the `AccountCreatedEvent` to allow the keyring (Snap) to make a suggestion for how the account should be named. 

MetaMask is responsible for allowing the user to accept or modify the proposed name.

## Examples

The Snap can call:

```typescript
await this.#emitEvent(KeyringEvent.AccountCreated, {
  account,
  accountNameSuggestion: "My Account",
});
```