### PR TITLE
docs: add `btc_sendmany` method

### DIFF
--- a/docs/btc-methods.md
+++ b/docs/btc-methods.md
@@ -11,7 +11,7 @@ camelCase. Also, dummy values aren't allowed.
 
 ### Parameters
 
-- **Request object (required):**
+- **Transaction intent (required)**
   - Type: `object`
   - Properties:
     - `amounts`

--- a/docs/btc-methods.md
+++ b/docs/btc-methods.md
@@ -38,7 +38,7 @@ camelCase. Also, dummy values aren't allowed.
 
 ### Returns
 
-- **Response object:**
+- **Transaction ID**
   - Type: `object`
   - Properties:
     - `txid`

--- a/docs/btc-methods.md
+++ b/docs/btc-methods.md
@@ -1,0 +1,73 @@
+# BTC Methods
+
+Here we document the Bitcoin methods that an account Snap may implement to
+support requests originated from dapps.
+
+## btc_sendmany
+
+This method is similar to the `sendmany` RPC method from Bitcoin Core, but its
+parameters are passed in an object instead of an array, and are named in
+camelCase. Also, dummy values aren't allowed.
+
+### Parameters
+
+- **Request object (required):**
+  - Type: `object`
+  - Properties:
+    - `amounts`
+      - Description: A JSON object with recipient addresses and amounts.
+      - Type: `object`
+      - Properties:
+        - `[key]: string`: Address of the recipient
+        - `[value]: string`: Amount to send to the recipient in BTC
+    - `comment` (optional)
+      - Description: A comment.
+      - Type: `string`
+    - `subtractFeeFrom` (optional)
+      - Description: The fee will be equally deducted from the amount of each
+        selected address. Those recipients will receive less bitcoins than you
+        enter in their corresponding amount field. If no addresses are specified
+        here, the sender pays the fee.
+      - Type: `array`
+      - Properties:
+        - Type: `string`
+    - `replaceable` (optional)
+      - Description: Allow this transaction to be replaced by a transaction
+        with higher fees via BIP 125.
+      - Type: `boolean`
+
+### Returns
+
+- **Response object:**
+  - Type: `object`
+  - Properties:
+    - `txid`
+      - Description: The transaction ID.
+      - Type: `string`
+
+### Examples
+
+**Request:**
+
+```json
+{
+  "method": "btc_sendmany",
+  "params": {
+    "amounts": {
+      "bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl": "0.01",
+      "bc1q02ad21edsxd23d32dfgqqsz4vv4nmtfzuklhy3": "0.02"
+    },
+    "comment": "testing",
+    "subtractFeeFrom": ["bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl"],
+    "replaceable": false
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "txid": "53de51e2fa75c3cfa51132865f7d430138b1cd92a8f5267ec836ec565b422969"
+}
+```

--- a/docs/btc-methods.md
+++ b/docs/btc-methods.md
@@ -29,7 +29,7 @@ camelCase. Also, dummy values aren't allowed.
         enter in their corresponding amount field. If no addresses are specified
         here, the sender pays the fee.
       - Type: `array`
-      - Properties:
+      - Items:
         - Type: `string`
     - `replaceable` (optional)
       - Description: Allow this transaction to be replaced by a transaction

--- a/docs/evm-methods.md
+++ b/docs/evm-methods.md
@@ -137,7 +137,7 @@ Adds support to [`eth_sendTransaction`][eth-send-transaction].
      - `accessList`:
        - Description: EIP-2930 access list
        - Type: `array`
-       - Properties:
+       - Items:
          - Type: `object`
          - Properties:
            - `address`
@@ -145,7 +145,7 @@ Adds support to [`eth_sendTransaction`][eth-send-transaction].
              - Pattern: `^0x[0-9a-fA-F]{40}$`
            - `storageKeys`
              - Type: `array`
-             - Properties:
+             - Items:
                - Type: `string`
                - Pattern: `^0x[0-9a-f]{64}$`
      - `chainId`

--- a/src/btc/types.ts
+++ b/src/btc/types.ts
@@ -24,7 +24,7 @@ export const BtcP2wpkhAddressStruct = refine(
  */
 export enum BtcMethod {
   // General transaction methods
-  SendTransaction = 'btc_sendTransaction',
+  SendMany = 'btc_sendmany',
 }
 
 /**
@@ -45,7 +45,7 @@ export const BtcP2wpkhAccountStruct = object({
   /**
    * Account supported methods.
    */
-  methods: array(enums([`${BtcMethod.SendTransaction}`])),
+  methods: array(enums([`${BtcMethod.SendMany}`])),
 });
 
 export type BtcP2wpkhAccount = Infer<typeof BtcP2wpkhAccountStruct>;


### PR DESCRIPTION
This PR documents the new `btc_sendmany` method that can be supported by Snaps to sign and broadcast Bitcoin transactions.