### PR TITLE
docs: put back GitHub admonitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,16 +37,18 @@ npm install @metamask/keyring-api
 
 ## Account Snaps
 
-> :point_up: **Important**: Before implementing your Snap, please make sure to
-> read the [security recommendations](./docs/security.md) and the [architecture
+> [!IMPORTANT]
+> Before implementing your Snap, please make sure to read the [security
+> recommendations](./docs/security.md) and the [architecture
 > document](./docs/architecture.md).
 
 Starting with MetaMask 11.4, Snaps can implement the Keyring API. This allows
 users to manage their accounts in a more flexible way, and enables developers
 to build new types of accounts.
 
-> :pencil2: **Note:** You can also build MetaMask from [source][extension-repo]
-> from the `develop` branch.
+> [!NOTE]
+> You can also build MetaMask from [source][extension-repo] from the `develop`
+> branch.
 
 Follow these steps to implement the Keyring API in your Snap. Please note that
 these instruction assume that you are already familiar with the process of
@@ -62,9 +64,9 @@ these instruction assume that you are already familiar with the process of
    }
    ```
 
-   > :point_up: **Important**: Ensure that your keyring implements the [methods
-   > called by MetaMask][exposed-methods], otherwise some features may not
-   > work.
+   > [!IMPORTANT]
+   > Ensure that your keyring implements the [methods called by
+   > MetaMask][exposed-methods], otherwise some features may not work.
 
 2. **Handle requests submitted by MetaMask:**
 
@@ -178,8 +180,9 @@ these instruction assume that you are already familiar with the process of
 
       MetaMask will return an error if the request does not exist.
 
-      > :pencil2: **Note:** This only applies to Snaps that implement the
-      > [asynchronous transaction flow][async-flow].
+      > [!NOTE]
+      > This only applies to Snaps that implement the [asynchronous transaction
+      > flow][async-flow].
 
    5. When a request is rejected:
 
@@ -196,8 +199,9 @@ these instruction assume that you are already familiar with the process of
 
       MetaMask will return an error if the request does not exist.
 
-      > :pencil2: **Note:** This only applies to Snaps that implement the
-      > [asynchronous transaction flow][async-flow].
+      > [!NOTE]
+      > This only applies to Snaps that implement the [asynchronous transaction
+      > flow][async-flow].
 
 4. **Expose the Keyring API:**
 
@@ -283,9 +287,9 @@ implementation:
   emitSnapKeyringEvent(snap, KeyringEvent.RequestRejected, { id: request.id });
   ```
 
-  > :point_up: **Important**: For all events above, MetaMask may return an error
-  > indicating that the event was not handled, possibly because it contains
-  > invalid arguments.
+  > [!IMPORTANT]
+  > For all events above, MetaMask may return an error indicating that the
+  > event was not handled, possibly because it contains invalid arguments.
 
 - Keyrings that implement the [asynchronous transaction flow][async-flow] can
   now return an optional `redirect` property that contains an URL and a message

--- a/docs/evm-methods.md
+++ b/docs/evm-methods.md
@@ -3,9 +3,10 @@
 Here we document the methods that an account Snap may implement to support
 requests originated from dapps.
 
-> :pencil2: **Note:** The methods described here may differ from the ones
-> defined in the [Ethereum JSON-RPC Specification][execution-api] or in
-> [MetaMask's API Reference][metamask-api-reference].
+> [!NOTE]
+> The methods described here may differ from the ones defined in the [Ethereum
+> JSON-RPC Specification][execution-api] or in [MetaMask's API
+> Reference][metamask-api-reference].
 
 ## personal_sign
 
@@ -50,8 +51,9 @@ Adds support to [`personal_sign`][personal-sign].
 
 Adds support to [`eth_sign`][eth-sign].
 
-> :warning: **Warning:** Please read the following articles to understand the
-> risks of using this method and its differences with `personal_sign`:
+> [!WARNING]
+> Please read the following articles to understand the risks of using this
+> method and its differences with `personal_sign`:
 >
 > - [What is 'eth_sign' and why is it a risk?][eth-sign-risk]
 > - [Sign data (MetaMask Docs)][sign-data]
@@ -227,8 +229,9 @@ Adds support to [`eth_sendTransaction`][eth-send-transaction].
 
 Adds support to [`eth_signtypeddata_v4`][eth-sign-typed-data].
 
-> :pencil2: **Note:** You can also implement support for `eth_signTypedData_v1`
-> and `eth_signTypedData_v3`, but they are [deprecated](#deprecated-methods).
+> [!NOTE]
+> You can also implement support for `eth_signTypedData_v1` and
+> `eth_signTypedData_v3`, but they are [deprecated](#deprecated-methods).
 >
 > In summary, the differences between the versions are:
 >

--- a/docs/security.md
+++ b/docs/security.md
@@ -139,10 +139,10 @@ async submitRequest(request: KeyringRequest): Promise<SubmitRequestResponse> {
 }
 ```
 
-> :point_up: **Important:** Only HTTPS URLs are allowed in the `url` field, and
-> the provided URL will be checked against a [list of blocked
-> domains][eth-phishing-detect]. However, for development purposes, HTTP URLs
-> are allowed on Flask.
+> [!IMPORTANT]
+> Only HTTPS URLs are allowed in the `url` field, and the provided URL will be
+> checked against a [list of blocked domains][eth-phishing-detect]. However,
+> for development purposes, HTTP URLs are allowed on Flask.
 >
 > We also enforce that the redirect URL links to a page within one of the
 > allowed origins present in the Snap's manifest.


### PR DESCRIPTION
The original bug that prevented the use of admonitions seems to have been silently fixed by GitHub, we can revert back to their syntax.