### PR TITLE
fix: remove signTransaction from EthErc4337Account

### DIFF
--- a/src/eth/types.test-d.ts
+++ b/src/eth/types.test-d.ts
@@ -75,7 +75,6 @@ expectAssignable<EthErc4337Account>({
   methods: [
     `${EthMethod.PersonalSign}`,
     `${EthMethod.Sign}`,
-    `${EthMethod.SignTransaction}`,
     `${EthMethod.SignTypedDataV1}`,
     `${EthMethod.SignTypedDataV3}`,
     `${EthMethod.SignTypedDataV4}`,

--- a/src/eth/types.ts
+++ b/src/eth/types.ts
@@ -87,7 +87,6 @@ export const EthErc4337AccountStruct = object({
     enums([
       `${EthMethod.PersonalSign}`,
       `${EthMethod.Sign}`,
-      `${EthMethod.SignTransaction}`,
       `${EthMethod.SignTypedDataV1}`,
       `${EthMethod.SignTypedDataV3}`,
       `${EthMethod.SignTypedDataV4}`,


### PR DESCRIPTION
This pull request removes the signTransaction method from the EthErc4337Account since it cannot sign transactions. 