### PR TITLE
fix: use internal `object` function instead of the upstream one

### DIFF
--- a/src/internal/events.ts
+++ b/src/internal/events.ts
@@ -1,9 +1,9 @@
 import { JsonStruct } from '@metamask/utils';
-import { boolean, literal, object, string } from 'superstruct';
+import { boolean, literal, string } from 'superstruct';
 
 import { KeyringAccountStruct } from '../api';
 import { KeyringEvent } from '../events';
-import { exactOptional } from '../superstruct';
+import { exactOptional, object } from '../superstruct';
 import { UuidStruct } from '../utils';
 
 export const AccountCreatedEventStruct = object({


### PR DESCRIPTION
This is needed to correctly support the `exactOptional` types.