### PR TITLE
feat: support @metamask/providers v17

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@metamask/eslint-config-jest": "^12.1.0",
     "@metamask/eslint-config-nodejs": "^12.1.0",
     "@metamask/eslint-config-typescript": "^12.1.0",
-    "@metamask/providers": "^16.1.0",
+    "@metamask/providers": "^17.0.0",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.12",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
@@ -79,7 +79,7 @@
     "typescript": "~4.8.4"
   },
   "peerDependencies": {
-    "@metamask/providers": ">=15 <17"
+    "@metamask/providers": ">=15 <18"
   },
   "packageManager": "yarn@3.2.1",
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1037,7 +1037,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/key-tree@npm:^9.1.0":
+"@metamask/key-tree@npm:^9.1.1":
   version: 9.1.1
   resolution: "@metamask/key-tree@npm:9.1.1"
   dependencies:
@@ -1061,7 +1061,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/providers": ^16.1.0
+    "@metamask/providers": ^17.0.0
     "@metamask/snaps-sdk": ^4.2.0
     "@metamask/utils": ^8.4.0
     "@types/jest": ^29.5.12
@@ -1092,7 +1092,7 @@ __metadata:
     typescript: ~4.8.4
     uuid: ^9.0.1
   peerDependencies:
-    "@metamask/providers": ">=15 <17"
+    "@metamask/providers": ">=15 <18"
   languageName: unknown
   linkType: soft
 
@@ -1106,9 +1106,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/providers@npm:^16.1.0":
-  version: 16.1.0
-  resolution: "@metamask/providers@npm:16.1.0"
+"@metamask/providers@npm:^17.0.0":
+  version: 17.0.0
+  resolution: "@metamask/providers@npm:17.0.0"
   dependencies:
     "@metamask/json-rpc-engine": ^8.0.1
     "@metamask/json-rpc-middleware-stream": ^7.0.1
@@ -1121,8 +1121,9 @@ __metadata:
     fast-deep-equal: ^3.1.3
     is-stream: ^2.0.0
     readable-stream: ^3.6.2
-    webextension-polyfill: ^0.10.0
-  checksum: 85e40140f342a38112c3d7cee436751a2be4c575cc4f815ab48a73b549abc2d756bf4a10e4b983e91dbd38076601f992531edb6d8d674aebceae32ef7e299275
+  peerDependencies:
+    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
+  checksum: 330e369458edc68d743d87b8b2597cdacac58df01b5fc31f565ae5dacee2390ee23693fb10fa451c6146665e87475a4c8f54163407eb05fceeb698900e34f9e6
   languageName: node
   linkType: hard
 
@@ -1154,16 +1155,16 @@ __metadata:
   linkType: hard
 
 "@metamask/snaps-sdk@npm:^4.2.0":
-  version: 4.3.0
-  resolution: "@metamask/snaps-sdk@npm:4.3.0"
+  version: 4.4.0
+  resolution: "@metamask/snaps-sdk@npm:4.4.0"
   dependencies:
-    "@metamask/key-tree": ^9.1.0
-    "@metamask/providers": ^16.1.0
+    "@metamask/key-tree": ^9.1.1
+    "@metamask/providers": ^17.0.0
     "@metamask/rpc-errors": ^6.2.1
     "@metamask/utils": ^8.3.0
     fast-xml-parser: ^4.3.4
     superstruct: ^1.0.3
-  checksum: 21c5724d53c54d6a98a74470f34fa9bd0bd697506f5bd21f43a4fabfaa70c04dd54c54db59e0eabbd643e8e0d3274872001537e7244916d24f88a4bbae260944
+  checksum: 79385cfefafc83d1f2886a86f40d928a8b7b474b95ff85277d27ed1cf6e3a5a75bd3606d4e7007a79ef882900856b59065b6193814fb4233a1a7c0a8302a3f4a
   languageName: node
   linkType: hard
 
@@ -7539,10 +7540,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webextension-polyfill@npm:>=0.10.0 <1.0, webextension-polyfill@npm:^0.10.0":
-  version: 0.10.0
-  resolution: "webextension-polyfill@npm:0.10.0"
-  checksum: 4a59036bda571360c2c0b2fb03fe1dc244f233946bcf9a6766f677956c40fd14d270aaa69cdba95e4ac521014afbe4008bfa5959d0ac39f91c990eb206587f91
+"webextension-polyfill@npm:>=0.10.0 <1.0":
+  version: 0.12.0
+  resolution: "webextension-polyfill@npm:0.12.0"
+  checksum: fc2166c8c9d3f32d7742727394092ff1a1eb19cbc4e5a73066d57f9bff1684e38342b90fabd23981e7295e904c536e8509552a64e989d217dae5de6ddca73532
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`@metamask/providers` v17 has been released.

This extends the `peerDependency` range to allow using the new version on to pof already supported versions.

Also bumps `devDependencies` versions to replace usage of `@metamask/providers@16` with `@metamask/providers@17`.