### PR TITLE
feat: allow multiple address per account

### DIFF
--- a/src/api/account.ts
+++ b/src/api/account.ts
@@ -1,6 +1,6 @@
 import { JsonStruct } from '@metamask/utils';
 import type { Infer } from 'superstruct';
-import { array, enums, record, string } from 'superstruct';
+import { array, enums, record, string, union } from 'superstruct';
 
 import { object } from '../superstruct';
 import { UuidStruct } from '../utils';
@@ -51,9 +51,35 @@ export const KeyringAccountStruct = object({
   ]),
 
   /**
-   * Account main address.
+   * Account addresses. It can be a single address or a map of addresses per
+   * chain.
+   *
+   * If the address is a string, it's assumed to be under the 'eip155'
+   * namespace. Otherwise, it must be a map of addresses per chain, where the
+   * key is the chain ID (CAIP-2) and the value is an array of addresses.
+   *
+   * @example
+   * ```ts
+   * address: {
+   *   // Different addresses per chain.
+   *   'eip155:1': ['0x1234...'],
+   *   'eip155:137': ['0x5678...'],
+   * }
+   * ```
+   * @example
+   * ```ts
+   * address: {
+   *   // The address is the same across all 'eip155' chains.
+   *   'eip155': ['0x1234...'],
+   * }
+   * ```
+   * @example
+   * ```ts
+   * // Assumed to be under the 'eip155' namespace.
+   * address: '0x1234...',
+   * ```
    */
-  address: string(),
+  address: union([string(), record(string(), array(string()))]),
 
   /**
    * Account options.

--- a/src/api/keyring.ts
+++ b/src/api/keyring.ts
@@ -81,12 +81,17 @@ export type Keyring = {
   /**
    * Filter supported chains for a given account.
    *
+   * See {@link KeyringAccount}.
+   *
+   * @deprecated Use the keys of the `address` map of the account object to
+   * indicate the supported chains. This method will be removed in a future
+   * version of the Keyring API.
    * @param id - ID of the account to be checked.
    * @param chains - List of chains (CAIP-2) to be checked.
    * @returns A Promise that resolves to a filtered list of CAIP-2 IDs
    * representing the supported chains.
    */
-  filterAccountChains(id: string, chains: string[]): Promise<string[]>;
+  filterAccountChains?(id: string, chains: string[]): Promise<string[]>;
 
   /**
    * Update an account.

--- a/src/rpc-handler.test.ts
+++ b/src/rpc-handler.test.ts
@@ -133,7 +133,25 @@ describe('handleKeyringRequest', () => {
     expect(result).toBe('FilterSupportedChains result');
   });
 
-  it('calls `keyring_updateAccount`', async () => {
+  it('fails because `keyring_filterAccountChains` is not implemented', async () => {
+    const request: JsonRpcRequest = {
+      jsonrpc: '2.0',
+      id: '7c507ff0-365f-4de0-8cd5-eb83c30ebda4',
+      method: 'keyring_filterAccountChains',
+      params: {
+        id: '4f983fa2-4f53-4c63-a7c2-f9a5ed750041',
+        chains: ['chain1', 'chain2'],
+      },
+    };
+
+    const { filterAccountChains, ...partialKeyring } = keyring;
+
+    await expect(handleKeyringRequest(partialKeyring, request)).rejects.toThrow(
+      'Method not supported: keyring_filterAccountChains',
+    );
+  });
+
+  it('calls keyring_updateAccount', async () => {
     const request: JsonRpcRequest = {
       jsonrpc: '2.0',
       id: '7c507ff0-365f-4de0-8cd5-eb83c30ebda4',

--- a/src/rpc-handler.ts
+++ b/src/rpc-handler.ts
@@ -74,6 +74,9 @@ async function dispatchRequest(
     }
 
     case KeyringRpcMethod.FilterAccountChains: {
+      if (keyring.filterAccountChains === undefined) {
+        throw new MethodNotSupportedError(request.method);
+      }
       assert(request, FilterAccountChainsStruct);
       return keyring.filterAccountChains(
         request.params.id,


### PR DESCRIPTION
This change will allow accounts to have multiple addresses for multiple chains. This PR was previously [merged](https://github.com/MetaMask/keyring-api/pull/315), but since it requires other components to be updated to support it, it was [reversed](https://github.com/MetaMask/keyring-api/pull/342) until we have time to work on them.

Fixes: https://github.com/MetaMask/accounts-planning/issues/464
Replaces: https://github.com/MetaMask/keyring-api/pull/315