### PR TITLE
chore: migrate to `@metamask/superstruct` and update required dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
   },
   "dependencies": {
     "@metamask/snaps-sdk": "^6.0.0",
+    "@metamask/superstruct": "^3.1.0",
     "@metamask/utils": "^9.0.0",
     "@types/uuid": "^9.0.8",
     "bech32": "^2.0.0",
-    "superstruct": "^1.0.3",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@metamask/snaps-sdk": "^6.0.0",
     "@metamask/superstruct": "^3.1.0",
-    "@metamask/utils": "^9.0.0",
+    "@metamask/utils": "^9.1.0",
     "@types/uuid": "^9.0.8",
     "bech32": "^2.0.0",
     "uuid": "^9.0.1"
@@ -53,7 +53,7 @@
     "@metamask/eslint-config-jest": "^12.1.0",
     "@metamask/eslint-config-nodejs": "^12.1.0",
     "@metamask/eslint-config-typescript": "^12.1.0",
-    "@metamask/providers": "^17.0.0",
+    "@metamask/providers": "^17.1.1",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.12",
     "@typescript-eslint/eslint-plugin": "^5.62.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@metamask/snaps-sdk": "^6.0.0",
-    "@metamask/utils": "^8.4.0",
+    "@metamask/utils": "^9.0.0",
     "@types/uuid": "^9.0.8",
     "bech32": "^2.0.0",
     "superstruct": "^1.0.3",

--- a/src/JsonRpcRequest.test.ts
+++ b/src/JsonRpcRequest.test.ts
@@ -1,4 +1,4 @@
-import { is } from 'superstruct';
+import { is } from '@metamask/superstruct';
 
 import { JsonRpcRequestStruct } from './JsonRpcRequest';
 

--- a/src/JsonRpcRequest.ts
+++ b/src/JsonRpcRequest.ts
@@ -1,6 +1,13 @@
+import {
+  array,
+  literal,
+  number,
+  record,
+  string,
+  union,
+} from '@metamask/superstruct';
+import type { Infer } from '@metamask/superstruct';
 import { JsonStruct } from '@metamask/utils';
-import type { Infer } from 'superstruct';
-import { array, literal, number, record, string, union } from 'superstruct';
 
 import { exactOptional, object } from './superstruct';
 

--- a/src/KeyringClient.ts
+++ b/src/KeyringClient.ts
@@ -1,5 +1,5 @@
+import { assert } from '@metamask/superstruct';
 import type { Json } from '@metamask/utils';
-import { assert } from 'superstruct';
 import { v4 as uuid } from 'uuid';
 
 import type {

--- a/src/api/account.test.ts
+++ b/src/api/account.test.ts
@@ -1,4 +1,4 @@
-import { assert } from 'superstruct';
+import { assert } from '@metamask/superstruct';
 
 import { KeyringAccountStruct } from './account';
 

--- a/src/api/account.ts
+++ b/src/api/account.ts
@@ -1,6 +1,6 @@
+import type { Infer } from '@metamask/superstruct';
+import { array, enums, record, string } from '@metamask/superstruct';
 import { JsonStruct } from '@metamask/utils';
-import type { Infer } from 'superstruct';
-import { array, enums, record, string } from 'superstruct';
 
 import { object } from '../superstruct';
 import { UuidStruct } from '../utils';

--- a/src/api/balance.ts
+++ b/src/api/balance.ts
@@ -1,5 +1,5 @@
-import type { Infer } from 'superstruct';
-import { string } from 'superstruct';
+import type { Infer } from '@metamask/superstruct';
+import { string } from '@metamask/superstruct';
 
 import { object } from '../superstruct';
 import { StringNumberStruct } from '../utils';

--- a/src/api/caip.ts
+++ b/src/api/caip.ts
@@ -1,4 +1,4 @@
-import { is, type Infer } from 'superstruct';
+import { is, type Infer } from '@metamask/superstruct';
 
 import { definePattern } from '../superstruct';
 

--- a/src/api/export.ts
+++ b/src/api/export.ts
@@ -1,6 +1,6 @@
+import type { Infer } from '@metamask/superstruct';
+import { record, string } from '@metamask/superstruct';
 import { JsonStruct } from '@metamask/utils';
-import type { Infer } from 'superstruct';
-import { record, string } from 'superstruct';
 
 export const KeyringAccountDataStruct = record(string(), JsonStruct);
 

--- a/src/api/request.ts
+++ b/src/api/request.ts
@@ -1,6 +1,6 @@
+import type { Infer } from '@metamask/superstruct';
+import { array, record, string, union } from '@metamask/superstruct';
 import { JsonStruct } from '@metamask/utils';
-import type { Infer } from 'superstruct';
-import { array, record, string, union } from 'superstruct';
 
 import { exactOptional, object } from '../superstruct';
 import { UuidStruct } from '../utils';

--- a/src/api/response.ts
+++ b/src/api/response.ts
@@ -1,6 +1,6 @@
+import type { Infer } from '@metamask/superstruct';
+import { literal, string, union } from '@metamask/superstruct';
 import { JsonStruct } from '@metamask/utils';
-import type { Infer } from 'superstruct';
-import { literal, string, union } from 'superstruct';
 
 import { exactOptional, object } from '../superstruct';
 

--- a/src/btc/types.ts
+++ b/src/btc/types.ts
@@ -1,6 +1,6 @@
+import type { Infer } from '@metamask/superstruct';
+import { string, array, enums, refine, literal } from '@metamask/superstruct';
 import { bech32 } from 'bech32';
-import type { Infer } from 'superstruct';
-import { string, array, enums, refine, literal } from 'superstruct';
 
 import { KeyringAccountStruct, BtcAccountType } from '../api';
 import { object } from '../superstruct';

--- a/src/eth/erc4337/types.test.ts
+++ b/src/eth/erc4337/types.test.ts
@@ -1,4 +1,4 @@
-import { assert } from 'superstruct';
+import { assert } from '@metamask/superstruct';
 
 import { EthUserOperationStruct, EthBaseUserOperationStruct } from './types';
 

--- a/src/eth/erc4337/types.ts
+++ b/src/eth/erc4337/types.ts
@@ -1,4 +1,4 @@
-import { type Infer } from 'superstruct';
+import { type Infer } from '@metamask/superstruct';
 
 import { exactOptional, object } from '../../superstruct';
 import { UrlStruct } from '../../utils';

--- a/src/eth/types.ts
+++ b/src/eth/types.ts
@@ -1,5 +1,5 @@
-import type { Infer } from 'superstruct';
-import { array, enums, literal } from 'superstruct';
+import type { Infer } from '@metamask/superstruct';
+import { array, enums, literal } from '@metamask/superstruct';
 
 import { EthAccountType, KeyringAccountStruct } from '../api';
 import { object, definePattern } from '../superstruct';

--- a/src/internal/api.ts
+++ b/src/internal/api.ts
@@ -1,6 +1,13 @@
+import type { Infer } from '@metamask/superstruct';
+import {
+  array,
+  literal,
+  number,
+  record,
+  string,
+  union,
+} from '@metamask/superstruct';
 import { JsonStruct } from '@metamask/utils';
-import type { Infer } from 'superstruct';
-import { array, literal, number, record, string, union } from 'superstruct';
 
 import {
   BalanceStruct,

--- a/src/internal/events.test.ts
+++ b/src/internal/events.test.ts
@@ -1,4 +1,4 @@
-import { is } from 'superstruct';
+import { is } from '@metamask/superstruct';
 
 import { EthAccountType } from '../api';
 import { KeyringEvent } from '../events';

--- a/src/internal/events.ts
+++ b/src/internal/events.ts
@@ -1,5 +1,5 @@
+import { boolean, literal, string } from '@metamask/superstruct';
 import { JsonStruct } from '@metamask/utils';
-import { boolean, literal, string } from 'superstruct';
 
 import { KeyringAccountStruct } from '../api';
 import { KeyringEvent } from '../events';

--- a/src/internal/types.test.ts
+++ b/src/internal/types.test.ts
@@ -1,4 +1,4 @@
-import { assert } from 'superstruct';
+import { assert } from '@metamask/superstruct';
 
 import { InternalAccountStruct } from '.';
 

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -1,5 +1,5 @@
-import type { Infer, Struct } from 'superstruct';
-import { boolean, string, number } from 'superstruct';
+import type { Infer, Struct } from '@metamask/superstruct';
+import { boolean, string, number } from '@metamask/superstruct';
 
 import { BtcAccountType, EthAccountType, KeyringAccountStruct } from '../api';
 import { BtcP2wpkhAccountStruct } from '../btc/types';

--- a/src/rpc-handler.ts
+++ b/src/rpc-handler.ts
@@ -1,5 +1,5 @@
+import { assert } from '@metamask/superstruct';
 import type { Json } from '@metamask/utils';
-import { assert } from 'superstruct';
 
 import type { Keyring } from './api';
 import {

--- a/src/superstruct.test-d.ts
+++ b/src/superstruct.test-d.ts
@@ -1,5 +1,5 @@
-import type { Infer } from 'superstruct';
-import { boolean, number, optional, string } from 'superstruct';
+import type { Infer } from '@metamask/superstruct';
+import { boolean, number, optional, string } from '@metamask/superstruct';
 import { expectAssignable, expectNotAssignable } from 'tsd';
 
 import { exactOptional, object } from '.';

--- a/src/superstruct.test.ts
+++ b/src/superstruct.test.ts
@@ -1,8 +1,8 @@
-import { is, literal, max, number, string, union } from 'superstruct';
+import { is, literal, max, number, string, union } from '@metamask/superstruct';
 
 import { exactOptional, object } from '.';
 
-describe('superstruct', () => {
+describe('@metamask/superstruct', () => {
   describe('exactOptional', () => {
     const simpleStruct = object({
       foo: exactOptional(string()),

--- a/src/superstruct.ts
+++ b/src/superstruct.ts
@@ -1,12 +1,18 @@
-import type { Infer, Context } from 'superstruct';
-import { Struct, assert, define, object as stObject } from 'superstruct';
+import {
+  Struct,
+  assert,
+  define,
+  object as stObject,
+} from '@metamask/superstruct';
 import type {
+  Infer,
+  Context,
   ObjectSchema,
   OmitBy,
   Optionalize,
   PickBy,
   Simplify,
-} from 'superstruct/dist/utils';
+} from '@metamask/superstruct';
 
 declare const ExactOptionalSymbol: unique symbol;
 

--- a/src/utils/types.test.ts
+++ b/src/utils/types.test.ts
@@ -1,4 +1,4 @@
-import { is } from 'superstruct';
+import { is } from '@metamask/superstruct';
 
 import { StringNumberStruct } from './types';
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,4 +1,4 @@
-import { define, type Infer } from 'superstruct';
+import { define, type Infer } from '@metamask/superstruct';
 
 import { definePattern } from '../superstruct';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1174,14 +1174,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/superstruct@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "@metamask/superstruct@npm:3.1.0"
-  checksum: 00e4d0c0aae8b25ccc1885c1db0bb4ed1590010570140c255e4deee3bf8a10c859c8fce5e475b4ae09c8a56316207af87585b91f7f5a5c028d668ccd111f19e3
-  languageName: node
-  linkType: hard
-
-"@metamask/utils@npm:^8.3.0, @metamask/utils@npm:^8.4.0":
+"@metamask/utils@npm:^8.3.0":
   version: 8.4.0
   resolution: "@metamask/utils@npm:8.4.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1063,6 +1063,7 @@ __metadata:
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/providers": ^17.0.0
     "@metamask/snaps-sdk": ^6.0.0
+    "@metamask/superstruct": ^3.1.0
     "@metamask/utils": ^9.0.0
     "@types/jest": ^29.5.12
     "@types/node": ^20.12.12
@@ -1084,7 +1085,6 @@ __metadata:
     prettier: ^2.8.8
     prettier-plugin-packagejson: ^2.5.0
     rimraf: ^5.0.7
-    superstruct: ^1.0.3
     ts-jest: ^28.0.8
     ts-node: ^10.9.2
     tsd: ^0.31.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -1063,7 +1063,7 @@ __metadata:
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/providers": ^17.0.0
     "@metamask/snaps-sdk": ^6.0.0
-    "@metamask/utils": ^8.4.0
+    "@metamask/utils": ^9.0.0
     "@types/jest": ^29.5.12
     "@types/node": ^20.12.12
     "@types/uuid": ^9.0.8
@@ -1174,7 +1174,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^8.3.0, @metamask/utils@npm:^8.4.0":
+"@metamask/superstruct@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@metamask/superstruct@npm:3.1.0"
+  checksum: 00e4d0c0aae8b25ccc1885c1db0bb4ed1590010570140c255e4deee3bf8a10c859c8fce5e475b4ae09c8a56316207af87585b91f7f5a5c028d668ccd111f19e3
+  languageName: node
+  linkType: hard
+
+"@metamask/utils@npm:^8.3.0":
   version: 8.4.0
   resolution: "@metamask/utils@npm:8.4.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1061,10 +1061,10 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/providers": ^17.0.0
+    "@metamask/providers": ^17.1.1
     "@metamask/snaps-sdk": ^6.0.0
     "@metamask/superstruct": ^3.1.0
-    "@metamask/utils": ^9.0.0
+    "@metamask/utils": ^9.1.0
     "@types/jest": ^29.5.12
     "@types/node": ^20.12.12
     "@types/uuid": ^9.0.8
@@ -1106,7 +1106,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/providers@npm:^17.0.0":
+"@metamask/providers@npm:^17.0.0, @metamask/providers@npm:^17.1.1":
   version: 17.1.1
   resolution: "@metamask/providers@npm:17.1.1"
   dependencies:
@@ -1191,9 +1191,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "@metamask/utils@npm:9.0.0"
+"@metamask/utils@npm:^9.0.0, @metamask/utils@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "@metamask/utils@npm:9.1.0"
   dependencies:
     "@ethereumjs/tx": ^4.2.0
     "@metamask/superstruct": ^3.1.0
@@ -1204,7 +1204,7 @@ __metadata:
     pony-cause: ^2.1.10
     semver: ^7.5.4
     uuid: ^9.0.1
-  checksum: 5dcb9d47c4768c33d451cc74c83207726c68b1340be1d091ca44105564f0ba0703026d357de7996de4459ac41cd420a0eb1f06db32f5ebbeeee581393f45fd44
+  checksum: 01f2c71a8f06158d5335bfe96bfd2f3aa39ec6b2323c5d0ff1d3136071a3e8ff7c1804d640ba1d4e07f96f3e68a95ff7729ddfcd34b373e5fefd86d6ef12d034
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1181,7 +1181,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^8.3.0":
+"@metamask/utils@npm:^8.3.0, @metamask/utils@npm:^8.4.0":
   version: 8.4.0
   resolution: "@metamask/utils@npm:8.4.0"
   dependencies:


### PR DESCRIPTION
Replaces: <https://github.com/MetaMask/keyring-api/pull/328>