### PR TITLE
Bump `@metamask/snaps-sdk` from `^6.0.0` to `^6.1.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/snaps-sdk": "^6.0.0",
+    "@metamask/snaps-sdk": "^6.1.0",
     "@metamask/superstruct": "^3.1.0",
     "@metamask/utils": "^9.1.0",
     "@types/uuid": "^9.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1085,7 +1085,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/providers": ^17.1.1
-    "@metamask/snaps-sdk": ^6.0.0
+    "@metamask/snaps-sdk": ^6.1.0
     "@metamask/superstruct": ^3.1.0
     "@metamask/utils": ^9.1.0
     "@types/jest": ^29.5.12
@@ -1198,7 +1198,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-sdk@npm:^6.0.0":
+"@metamask/snaps-sdk@npm:^6.1.0":
   version: 6.1.0
   resolution: "@metamask/snaps-sdk@npm:6.1.0"
   dependencies:


### PR DESCRIPTION
## Motivation

Aligns dependency versions with sibling packages to fix/prevent build errors caused by nested dependency version mismatch:
  - e.g. https://github.com/MetaMask/snaps/actions/runs/9720788583/job/26900545288?pr=2445

## Changelog

```md
### Changed

- Bump `@metamask/snaps-sdk` from `^6.0.0` to `^6.1.0` ([#358](https://github.com/MetaMask/keyring-api/pull/358))
```

## References

- https://github.com/MetaMask/core/pull/3645
- https://github.com/MetaMask/snaps/pull/2445