### PR TITLE
feat: add new optional  field in `InternalAccount` metadata

### DIFF
--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -1,5 +1,5 @@
 import type { Infer, Struct } from '@metamask/superstruct';
-import { boolean, string, number } from '@metamask/superstruct';
+import { boolean, string, number, array } from '@metamask/superstruct';
 
 import { BtcAccountType, EthAccountType, KeyringAccountStruct } from '../api';
 import { BtcP2wpkhAccountStruct } from '../btc/types';
@@ -11,6 +11,7 @@ export type InternalAccountType = EthAccountType | BtcAccountType;
 export const InternalAccountMetadataStruct = object({
   metadata: object({
     name: string(),
+    conflictingNames: exactOptional(array(string())),
     snap: exactOptional(
       object({
         id: string(),


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

UPDATE: Drafting this PR for now since there's a chance we might not need this feature ATM.

This PR adds a new optional field for `InternalAccount` metadata, `conflictingNames`.
This field will be crucial in the implementation of the new Account syncing feature (from @MetaMask/notifications ).
It will be used to temporarily store conflicting account names in the client after a successful account sync but with name conflicts. This metadata field will then be cleared when a user choses the correct account name from the UI.

Related to [this Epic](https://consensyssoftware.atlassian.net/jira/software/projects/NOTIFY/boards/616?assignee=712020%3A5843b7e2-a7fe-4c45-9fbd-e1f2b2eb58c2&selectedIssue=NOTIFY-851)

## Examples

This will be used by the `AccountsController` to get the correct `InternalAccount` type and get/set the new `conflictingNames` field when needed.

Ref: https://github.com/MetaMask/core/tree/main/packages/accounts-controller
