### PR TITLE
feat: add `nameLastUpdatedAt` metadata field

### DIFF
--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -11,6 +11,7 @@ export type InternalAccountType = EthAccountType | BtcAccountType;
 export const InternalAccountMetadataStruct = object({
   metadata: object({
     name: string(),
+    nameLastUpdatedAt: exactOptional(number()),
     snap: exactOptional(
       object({
         id: string(),


### PR DESCRIPTION
This PR adds a new optional field to `InternalAccount` metadata, `nameLastUpdatedAt`.
This field will be crucial in the implementation of the new Account syncing feature (from @MetaMask/notifications ).

It will be used to store a timestamp so we can compare which manual name update is more recent, and then overwrite the account name accordingly when syncing accounts between devices.

## Examples

This will be used by the `AccountsController` method `setAccountName` to set the timestamp of a manual name update.

This will also be used by `UserStorageController` when syncing accounts, in order to determine which name is the most recent, and thus the source of truth.
